### PR TITLE
Add 'hideBodyClassName' to AccordionItem and AccordionItemTitle components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ ReactDOM.render(<Example />, document.querySelector('[data-mount]'));
           <td>accordion__item</td>
           <td>CSS class(es) applied to the component</td>
       </tr>
+      <tr>
+          <td>hideBodyClassName</td>
+          <td>String</td>
+          <td>null</td>
+          <td>Class name for hidden body state</td>
+      </tr>
     </tbody>
 </table>
 
@@ -144,6 +150,12 @@ ReactDOM.render(<Example />, document.querySelector('[data-mount]'));
           <td>String</td>
           <td>accordion__title</td>
           <td>CSS class(es) applied to the component</td>
+      </tr>
+      <tr>
+          <td>hideBodyClassName</td>
+          <td>String</td>
+          <td>null</td>
+          <td>Class name for hidden body state</td>
       </tr>
     </tbody>
 </table>

--- a/src/AccordionItem/__snapshots__/accordion-item.spec.js.snap
+++ b/src/AccordionItem/__snapshots__/accordion-item.spec.js.snap
@@ -141,6 +141,33 @@ exports[`AccordionItem renders with different className 1`] = `
 </div>
 `;
 
+exports[`AccordionItem renders with different hideBodyClassName 1`] = `
+<div
+  className="accordion__item testCSSClass--hidden"
+>
+  <div
+    ariaControls="accordion__body-mock-uuid-hash"
+    expanded={false}
+    id="accordion__title-mock-uuid-hash"
+    onClick={[Function]}
+    role="tab"
+  >
+    <div>
+      Fake title
+    </div>
+  </div>
+  <div
+    expanded={false}
+    id="accordion__body-mock-uuid-hash"
+    role="tabpanel"
+  >
+    <div>
+      Fake body
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AccordionItem still renders with no AccordionItemTitle or AccordionItemBody 1`] = `
 <div
   className="accordion__item"

--- a/src/AccordionItem/accordion-item.js
+++ b/src/AccordionItem/accordion-item.js
@@ -1,12 +1,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import uuid from 'uuid';
+import classNames from 'classnames';
 
 const defaultProps = {
     accordion: true,
     expanded: false,
     onClick: () => {},
     className: 'accordion__item',
+    hideBodyClassName: null,
 };
 
 const propTypes = {
@@ -15,6 +17,7 @@ const propTypes = {
     expanded: PropTypes.bool,
     children: PropTypes.arrayOf(PropTypes.element).isRequired,
     className: PropTypes.string,
+    hideBodyClassName: PropTypes.string,
 };
 
 class AccordionItem extends Component {
@@ -56,9 +59,17 @@ class AccordionItem extends Component {
     }
 
     render() {
-        const { className } = this.props;
+        const { className, expanded, hideBodyClassName } = this.props;
+
+        const itemClassName = classNames(
+            className,
+            {
+                [hideBodyClassName]: (!expanded && hideBodyClassName),
+            },
+        );
+
         return (
-            <div className={className}>
+            <div className={itemClassName}>
                 {this.renderChildren()}
             </div>
         );

--- a/src/AccordionItem/accordion-item.spec.js
+++ b/src/AccordionItem/accordion-item.spec.js
@@ -88,6 +88,20 @@ describe('AccordionItem', () => {
         expect(tree).toMatchSnapshot();
     });
 
+    it('renders with different hideBodyClassName', () => {
+        const tree = renderer.create(
+            <AccordionItem expanded={false} hideBodyClassName="testCSSClass--hidden">
+                <AccordionItemTitle>
+                    <div>Fake title</div>
+                </AccordionItemTitle>
+                <AccordionItemBody>
+                    <div>Fake body</div>
+                </AccordionItemBody>
+            </AccordionItem>,
+        ).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
     it('renders correctly with other blocks inside', () => {
         const tree = renderer.create(
             <AccordionItem accordion={false}>

--- a/src/AccordionItemTitle/__snapshots__/accordion-item-title.spec.js.snap
+++ b/src/AccordionItemTitle/__snapshots__/accordion-item-title.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AccordionItemTitle doesn't respect hideBodyClassName when collapsed 1`] = `
+<div
+  aria-controls=""
+  aria-expanded={true}
+  className="accordion__title"
+  id=""
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role=""
+  tabIndex="0"
+>
+  <div>
+    Fake title
+  </div>
+</div>
+`;
+
 exports[`AccordionItemTitle renders correctly when pressing another key 1`] = `
 <div
   aria-controls=""
@@ -81,6 +98,23 @@ exports[`AccordionItemTitle renders correctly with min params 1`] = `
 >
   <div>
     Fake Title
+  </div>
+</div>
+`;
+
+exports[`AccordionItemTitle renders with different hideBodyClassName 1`] = `
+<div
+  aria-controls=""
+  aria-expanded={false}
+  className="accordion__title testCSSClass--hidden"
+  id=""
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role=""
+  tabIndex="0"
+>
+  <div>
+    Fake title
   </div>
 </div>
 `;

--- a/src/AccordionItemTitle/accordion-item-title.js
+++ b/src/AccordionItemTitle/accordion-item-title.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classNames from 'classnames';
 
 const defaultProps = {
     id: '',
@@ -7,6 +8,7 @@ const defaultProps = {
     onClick: () => {},
     ariaControls: '',
     className: 'accordion__title',
+    hideBodyClassName: null,
     role: '',
 };
 
@@ -20,6 +22,7 @@ const propTypes = {
         PropTypes.arrayOf(PropTypes.element),
     ]).isRequired,
     className: PropTypes.string,
+    hideBodyClassName: PropTypes.string,
     role: PropTypes.string,
 };
 
@@ -37,13 +40,20 @@ class AccordionItemTitle extends Component {
     }
 
     render() {
-        const { id, expanded, ariaControls, onClick, children, className, role } = this.props;
+        const { id, expanded, ariaControls, onClick, children, className, role, hideBodyClassName } = this.props;
+        const titleClassName = classNames(
+            className,
+            {
+                [hideBodyClassName]: (hideBodyClassName && !expanded),
+            },
+        );
+
         return (
             <div // eslint-disable-line jsx-a11y/no-static-element-interactions
                 id={id}
                 aria-expanded={expanded}
                 aria-controls={ariaControls}
-                className={className}
+                className={titleClassName}
                 onClick={onClick}
                 role={role}
                 tabIndex="0"

--- a/src/AccordionItemTitle/accordion-item-title.spec.js
+++ b/src/AccordionItemTitle/accordion-item-title.spec.js
@@ -22,6 +22,24 @@ describe('AccordionItemTitle', () => {
         expect(tree).toMatchSnapshot();
     });
 
+    it('renders with different hideBodyClassName', () => {
+        const tree = renderer.create(
+            <AccordionItemTitle expanded={false} hideBodyClassName="testCSSClass--hidden">
+                <div>Fake title</div>
+            </AccordionItemTitle>,
+        ).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('doesn\'t respect hideBodyClassName when collapsed', () => {
+        const tree = renderer.create(
+            <AccordionItemTitle expanded={true} hideBodyClassName="testCSSClass--hidden">
+                <div>Fake title</div>
+            </AccordionItemTitle>,
+        ).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
     it('renders correctly when pressing enter', () => {
         const mockOnClick = jest.fn();
         const tree = renderer.create(


### PR DESCRIPTION
At the moment it's not possible to have stylesheet-level control over the AccordionItem and AccordionItemTitle components' collapsed/hidden states. Simply recycled the existing 'hideBodyClassName' props from the AccordionItemBody component, except with 'null' defaults.