### PR TITLE
Chore/hardcode aria labelledby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Version 2.1 represents changes to devDependencies only, and should have no backw
 
 * Upgrade all dev-dependencies except the eslint configs.
 
+## [[v2.0.1]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.0.1)
+
+### Changed
+
+* Minor syntax change in AccordionItemBody
+
 ## [[v2.0.0]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.0.0)
 
 Version 2.0 represents a total refactor, with a new context-based approach which should make this library more flexible, more maintainable and more comprehensively testable.

--- a/src/AccordionItemBody/accordion-item-body.js
+++ b/src/AccordionItemBody/accordion-item-body.js
@@ -27,6 +27,7 @@ const AccordionItemBody = (props: AccordionItemBodyProps) => {
 
     const { expanded } = foundItem;
     const id = `accordion__body-${uuid}`;
+    const ariaLabelledby = `accordion__title-${uuid}`;
     const role = accordion ? 'tabpanel' : null;
 
     const bodyClass = classNames(className, {
@@ -38,10 +39,7 @@ const AccordionItemBody = (props: AccordionItemBodyProps) => {
             id={id}
             className={bodyClass}
             aria-hidden={ariaHidden}
-            aria-labelledby={id.replace(
-                'accordion__body-',
-                'accordion__title-',
-            )}
+            aria-labelledby={ariaLabelledby}
             role={role}
         >
             {children}


### PR DESCRIPTION
We were doing an unnecessary `.replace` in order to interpolate a string value which we should have just hardcoded.