### PR TITLE
Chore/update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 > All notable changes to this project are documented in this file.
 > This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [[v2.0.1]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.0.0)
-
-Version 2.1 represents changes to devDependencies only, and should have no backward-incompatible effect on this library.
+## [[v2.0.1]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.0.1)
 
 ### Changed
 
 * Upgrade all dev-dependencies except the eslint configs.
+* Replace snapshot tests with explicit assertions in AccordionItemBody and AccordionItemTitle.
+* Add specific assertions to tests in accordionStore.
 
 ## [[v2.0.0]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.0.0)
 

--- a/src/AccordionItemBody/__snapshots__/accordion-item-body.spec.js.snap
+++ b/src/AccordionItemBody/__snapshots__/accordion-item-body.spec.js.snap
@@ -13,17 +13,3 @@ exports[`AccordionItemBody renders correctly with min params 1`] = `
   </div>
 </div>
 `;
-
-exports[`AccordionItemBody renders correctly with prefixClass 1`] = `
-<div
-  aria-hidden={true}
-  aria-labelledby="accordion__title-asdf-1234"
-  className="accordion__body testCSSClass--hidden"
-  id="accordion__body-asdf-1234"
-  role="tabpanel"
->
-  <div>
-    Fake body
-  </div>
-</div>
-`;

--- a/src/AccordionItemBody/__snapshots__/accordion-item-body.spec.js.snap
+++ b/src/AccordionItemBody/__snapshots__/accordion-item-body.spec.js.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AccordionItemBody renders correctly with different className 1`] = `
-<div
-  aria-hidden={true}
-  aria-labelledby="accordion__title-asdf-1234"
-  className="testCSSClass accordion__body--hidden"
-  id="accordion__body-asdf-1234"
-  role="tabpanel"
->
-  <div>
-    Fake body
-  </div>
-</div>
-`;
-
 exports[`AccordionItemBody renders correctly with min params 1`] = `
 <div
   aria-hidden={true}

--- a/src/AccordionItemBody/accordion-item-body.spec.js
+++ b/src/AccordionItemBody/accordion-item-body.spec.js
@@ -46,17 +46,14 @@ describe('AccordionItemBody', () => {
         expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
-    it('renders correctly with prefixClass', () => {
-        const tree = renderer
-            .create(
-                <Provider accordionStore={accordionStore} uuid={uuid}>
-                    <AccordionItemBody hideBodyClassName="testCSSClass--hidden">
-                        <div>Fake body</div>
-                    </AccordionItemBody>
-                </Provider>,
-            )
-            .toJSON();
-        expect(tree).toMatchSnapshot();
+    it('renders correctly with different hideBodyClassName', () => {
+        const hideBodyClassName = 'hideBodyClassName';
+        const wrapper = mount(
+            <Provider accordionStore={accordionStore} uuid={uuid}>
+                <AccordionItemBody hideBodyClassName={hideBodyClassName} />
+            </Provider>,
+        );
+        expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(true);
     });
 
     it('renders null if an associated AccordionItem is not registered in accordionStore', () => {

--- a/src/AccordionItemBody/accordion-item-body.spec.js
+++ b/src/AccordionItemBody/accordion-item-body.spec.js
@@ -37,16 +37,13 @@ describe('AccordionItemBody', () => {
     });
 
     it('renders correctly with different className', () => {
-        const tree = renderer
-            .create(
-                <Provider accordionStore={accordionStore} uuid={uuid}>
-                    <AccordionItemBody className="testCSSClass">
-                        <div>Fake body</div>
-                    </AccordionItemBody>
-                </Provider>,
-            )
-            .toJSON();
-        expect(tree).toMatchSnapshot();
+        const className = 'className';
+        const wrapper = mount(
+            <Provider accordionStore={accordionStore} uuid={uuid}>
+                <AccordionItemBody className={className} />
+            </Provider>,
+        );
+        expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
     it('renders correctly with prefixClass', () => {

--- a/src/AccordionItemTitle/__snapshots__/accordion-item-title.spec.js.snap
+++ b/src/AccordionItemTitle/__snapshots__/accordion-item-title.spec.js.snap
@@ -1,41 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AccordionItemTitle doesn't respect hideBodyClassName when collapsed 1`] = `
-<div
-  aria-controls="accordion__body-item-two-uuid"
-  aria-expanded={true}
-  className="accordion__title"
-  disabled={false}
-  id="accordion__title-item-two-uuid"
-  onClick={[Function]}
-  onKeyPress={[Function]}
-  role="button"
-  tabIndex="0"
->
-  <div>
-    Fake title
-  </div>
-</div>
-`;
-
-exports[`AccordionItemTitle renders correctly with different className 1`] = `
-<div
-  aria-controls="accordion__body-item-one-uuid"
-  aria-expanded={false}
-  className="testCSSClass"
-  disabled={false}
-  id="accordion__title-item-one-uuid"
-  onClick={[Function]}
-  onKeyPress={[Function]}
-  role="button"
-  tabIndex="0"
->
-  <div>
-    Fake Title
-  </div>
-</div>
-`;
-
 exports[`AccordionItemTitle renders correctly with min params 1`] = `
 <div
   aria-controls="accordion__body-item-one-uuid"
@@ -50,24 +14,6 @@ exports[`AccordionItemTitle renders correctly with min params 1`] = `
 >
   <div>
     Fake Title
-  </div>
-</div>
-`;
-
-exports[`AccordionItemTitle renders with different hideBodyClassName 1`] = `
-<div
-  aria-controls="accordion__body-item-one-uuid"
-  aria-expanded={false}
-  className="accordion__title testCSSClass--hidden"
-  disabled={false}
-  id="accordion__title-item-one-uuid"
-  onClick={[Function]}
-  onKeyPress={[Function]}
-  role="button"
-  tabIndex="0"
->
-  <div>
-    Fake title
   </div>
 </div>
 `;

--- a/src/AccordionItemTitle/accordion-item-title.spec.js
+++ b/src/AccordionItemTitle/accordion-item-title.spec.js
@@ -46,48 +46,39 @@ describe('AccordionItemTitle', () => {
     });
 
     it('renders correctly with different className', () => {
-        const tree = renderer
-            .create(
-                <AccordionItemTitle
-                    className="testCSSClass"
-                    accordionStore={accordionStore}
-                    uuid="item-one-uuid"
-                >
-                    <div>Fake Title</div>
-                </AccordionItemTitle>,
-            )
-            .toJSON();
-        expect(tree).toMatchSnapshot();
+        const className = 'className';
+        const wrapper = mount(
+            <AccordionItemTitle
+                className={className}
+                accordionStore={accordionStore}
+                uuid="item-one-uuid"
+            />,
+        );
+        expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
     it('renders with different hideBodyClassName', () => {
-        const tree = renderer
-            .create(
-                <AccordionItemTitle
-                    hideBodyClassName="testCSSClass--hidden"
-                    accordionStore={accordionStore}
-                    uuid="item-one-uuid"
-                >
-                    <div>Fake title</div>
-                </AccordionItemTitle>,
-            )
-            .toJSON();
-        expect(tree).toMatchSnapshot();
+        const hideBodyClassName = 'hideBodyClassName';
+        const wrapper = mount(
+            <AccordionItemTitle
+                hideBodyClassName={hideBodyClassName}
+                accordionStore={accordionStore}
+                uuid="item-one-uuid"
+            />,
+        );
+        expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(true);
     });
 
-    it("doesn't respect hideBodyClassName when collapsed", () => {
-        const tree = renderer
-            .create(
-                <AccordionItemTitle
-                    hideBodyClassName="testCSSClass--hidden"
-                    accordionStore={accordionStore}
-                    uuid="item-two-uuid"
-                >
-                    <div>Fake title</div>
-                </AccordionItemTitle>,
-            )
-            .toJSON();
-        expect(tree).toMatchSnapshot();
+    it("doesn't present hideBodyClassName when collapsed", () => {
+        const hideBodyClassName = 'hideBodyClassName';
+        const wrapper = mount(
+            <AccordionItemTitle
+                hideBodyClassName={hideBodyClassName}
+                accordionStore={accordionStore}
+                uuid="item-two-uuid"
+            />,
+        );
+        expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(false);
     });
 
     it('renders correctly when pressing enter', async () => {

--- a/src/accordionStore/accordionStore.spec.js
+++ b/src/accordionStore/accordionStore.spec.js
@@ -50,6 +50,9 @@ describe('accordionStore', () => {
             expect(store.items.length).toEqual(2);
             store.removeItem('foo');
             expect(store.items.length).toEqual(1);
+            expect(store.items.find(item => item.uuid === 'foo')).toEqual(
+                undefined,
+            );
         });
 
         it('can modify the expanded property of an item', () => {
@@ -71,7 +74,12 @@ describe('accordionStore', () => {
             });
 
             store.setExpanded('foo', false);
-            expect(store.items.filter(item => item.expanded).length).toEqual(1);
+
+            const expandedItems = store.items.filter(item => item.expanded);
+            expect(expandedItems.length).toEqual(1);
+            expect(expandedItems.find(item => item.uuid === 'foo')).toEqual(
+                undefined,
+            );
         });
 
         it('will collapse any open item if accordion=true', () => {


### PR DESCRIPTION
As per comments on the big v2.0.0 PR, there were areas where the tests could have been updated, namely:

- Less snapshot tests / more explicit assertions in AccordionItemTitle and AccordionItemBody.
- More specific assertions in accordionStore.