### PR TITLE
Only do npm build on 'prebublishOnly'

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pages": "rm -rf pages && cp -R demo pages && webpack --config=./webpack/webpack.config.pages.js",
     "deploy": "npm run pages && ./bin/deploy.sh",
     "prettier": "prettier **/*.js --write",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We don't want to run `npm run build` whenever you `npm install`, so changed the build hook from `prepublish` to `prepublishOnly` as per [the docs](https://docs.npmjs.com/misc/scripts).