### PR TITLE
Remove 'Next' heading on Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 > All notable changes to this project are documented in this file.
 > This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Next
-
 ## [[v2.2.0]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.2.0)
 
 ### Added


### PR DESCRIPTION
That's only really meant to be added in pre-release branches.