### PR TITLE
expanded -> selected

### DIFF
--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -82,7 +82,7 @@
     transform: rotate(45deg);
 }
 
-[aria-expanded='true'] .accordion__arrow::before {
+[aria-selected='true'] .accordion__arrow::before {
     transform: rotate(-45deg);
 }
 
@@ -91,7 +91,7 @@
     transform: rotate(-45deg);
 }
 
-[aria-expanded='true'] .accordion__arrow::after {
+[aria-selected='true'] .accordion__arrow::after {
     transform: rotate(45deg);
 }
 


### PR DESCRIPTION
Was trying to implement the arrow flipping upside down and realized the attribute was `aria-selected` not `aria-expanded`. If this was intended simply disregard and close this. New to this repo (< 1 hr)