### PR TITLE
Adds possibility of custom uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Next
 
+### Added
+
+*   Possibility to have custom uuid on `AccordionItem` - suggested by https://github.com/springload/react-accessible-accordion/issues/70
+
 ### Fixed
 
 *   Fix rollup config after version bump - https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ We recommend that you copy them into your own app and modify them to suit your n
           <td>null</td>
           <td>Class name for hidden body state</td>
       </tr>
+      <tr>
+          <td>uuid</td>
+          <td>String</td>
+          <td>null</td>
+          <td>Custom uuid to be passed to Accordion - onChange. Has to be unique.</td>
+      </tr>
     </tbody>
 </table>
 

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -1,3 +1,5 @@
+/* eslint no-console: 0 */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -565,6 +567,39 @@ const Example = () => (
                 </AccordionItemTitle>
                 <AccordionItemBody>
                     <p>Why would you need more than one?</p>
+                </AccordionItemBody>
+            </AccordionItem>
+        </Accordion>
+
+        <h2 className="u-margin-top">Informative onChange</h2>
+
+        <Accordion onChange={itemUuid => console.log(itemUuid)}>
+            <AccordionItem uuid="uniqueItem-1">
+                <AccordionItemTitle>
+                    <h3 className="u-position-relative">
+                        Unique Item #1
+                        <div className="accordion__arrow" role="presentation" />
+                    </h3>
+                </AccordionItemTitle>
+                <AccordionItemBody>
+                    <p>
+                        If you open/close this item you should see
+                        `uniqueItem-1` printed in the console.
+                    </p>
+                </AccordionItemBody>
+            </AccordionItem>
+            <AccordionItem uuid="uniqueItem-2">
+                <AccordionItemTitle>
+                    <h3 className="u-position-relative">
+                        Unique Item #2
+                        <div className="accordion__arrow" role="presentation" />
+                    </h3>
+                </AccordionItemTitle>
+                <AccordionItemBody>
+                    <p>
+                        If you open/close this item you should see
+                        `uniqueItem-2` printed in the console.
+                    </p>
                 </AccordionItemBody>
             </AccordionItem>
         </Accordion>

--- a/src/AccordionItem/__snapshots__/accordion-item.spec.js.snap
+++ b/src/AccordionItem/__snapshots__/accordion-item.spec.js.snap
@@ -3,18 +3,6 @@
 exports[`AccordionItem renders correctly with accordion false 1`] = `
 <div
   className="accordion__item"
-  itemstore={
-    ItemContainer {
-      "_listeners": Array [
-        [Function],
-        [Function],
-        [Function],
-      ],
-      "state": Object {
-        "uuid": 0,
-      },
-    }
-  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -48,18 +36,6 @@ exports[`AccordionItem renders correctly with accordion false 1`] = `
 exports[`AccordionItem renders correctly with accordion true 1`] = `
 <div
   className="accordion__item"
-  itemstore={
-    ItemContainer {
-      "_listeners": Array [
-        [Function],
-        [Function],
-        [Function],
-      ],
-      "state": Object {
-        "uuid": 0,
-      },
-    }
-  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -93,18 +69,6 @@ exports[`AccordionItem renders correctly with accordion true 1`] = `
 exports[`AccordionItem renders correctly with other blocks inside 1`] = `
 <div
   className="accordion__item"
-  itemstore={
-    ItemContainer {
-      "_listeners": Array [
-        [Function],
-        [Function],
-        [Function],
-      ],
-      "state": Object {
-        "uuid": 0,
-      },
-    }
-  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -141,18 +105,6 @@ exports[`AccordionItem renders correctly with other blocks inside 1`] = `
 exports[`AccordionItem renders correctly with other blocks inside 2 1`] = `
 <div
   className="accordion__item"
-  itemstore={
-    ItemContainer {
-      "_listeners": Array [
-        [Function],
-        [Function],
-        [Function],
-      ],
-      "state": Object {
-        "uuid": 0,
-      },
-    }
-  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -189,16 +141,6 @@ exports[`AccordionItem renders correctly with other blocks inside 2 1`] = `
 exports[`AccordionItem still renders with no AccordionItemTitle or AccordionItemBody 1`] = `
 <div
   className="accordion__item"
-  itemstore={
-    ItemContainer {
-      "_listeners": Array [
-        [Function],
-      ],
-      "state": Object {
-        "uuid": 0,
-      },
-    }
-  }
 >
   <div>
     Fake title
@@ -212,15 +154,5 @@ exports[`AccordionItem still renders with no AccordionItemTitle or AccordionItem
 exports[`AccordionItem still renders with no children at all 1`] = `
 <div
   className="accordion__item"
-  itemstore={
-    ItemContainer {
-      "_listeners": Array [
-        [Function],
-      ],
-      "state": Object {
-        "uuid": 0,
-      },
-    }
-  }
 />
 `;

--- a/src/AccordionItem/__snapshots__/accordion-item.spec.js.snap
+++ b/src/AccordionItem/__snapshots__/accordion-item.spec.js.snap
@@ -3,6 +3,18 @@
 exports[`AccordionItem renders correctly with accordion false 1`] = `
 <div
   className="accordion__item"
+  itemstore={
+    ItemContainer {
+      "_listeners": Array [
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "state": Object {
+        "uuid": 0,
+      },
+    }
+  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -36,6 +48,18 @@ exports[`AccordionItem renders correctly with accordion false 1`] = `
 exports[`AccordionItem renders correctly with accordion true 1`] = `
 <div
   className="accordion__item"
+  itemstore={
+    ItemContainer {
+      "_listeners": Array [
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "state": Object {
+        "uuid": 0,
+      },
+    }
+  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -69,6 +93,18 @@ exports[`AccordionItem renders correctly with accordion true 1`] = `
 exports[`AccordionItem renders correctly with other blocks inside 1`] = `
 <div
   className="accordion__item"
+  itemstore={
+    ItemContainer {
+      "_listeners": Array [
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "state": Object {
+        "uuid": 0,
+      },
+    }
+  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -105,6 +141,18 @@ exports[`AccordionItem renders correctly with other blocks inside 1`] = `
 exports[`AccordionItem renders correctly with other blocks inside 2 1`] = `
 <div
   className="accordion__item"
+  itemstore={
+    ItemContainer {
+      "_listeners": Array [
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "state": Object {
+        "uuid": 0,
+      },
+    }
+  }
 >
   <div
     aria-controls="accordion__body-0"
@@ -141,6 +189,16 @@ exports[`AccordionItem renders correctly with other blocks inside 2 1`] = `
 exports[`AccordionItem still renders with no AccordionItemTitle or AccordionItemBody 1`] = `
 <div
   className="accordion__item"
+  itemstore={
+    ItemContainer {
+      "_listeners": Array [
+        [Function],
+      ],
+      "state": Object {
+        "uuid": 0,
+      },
+    }
+  }
 >
   <div>
     Fake title
@@ -154,5 +212,15 @@ exports[`AccordionItem still renders with no AccordionItemTitle or AccordionItem
 exports[`AccordionItem still renders with no children at all 1`] = `
 <div
   className="accordion__item"
+  itemstore={
+    ItemContainer {
+      "_listeners": Array [
+        [Function],
+      ],
+      "state": Object {
+        "uuid": 0,
+      },
+    }
+  }
 />
 `;

--- a/src/AccordionItem/accordion-item-wrapper.js
+++ b/src/AccordionItem/accordion-item-wrapper.js
@@ -13,6 +13,7 @@ type AccordionItemWrapperProps = ElementProps<'div'> & {
     disabled: ?boolean,
     expanded: ?boolean,
     accordionStore: AccordionContainer,
+    uuid?: string,
 };
 
 const defaultProps = {
@@ -21,6 +22,7 @@ const defaultProps = {
     disabled: false,
     expanded: false,
     accordionStore: new AccordionContainer(),
+    uuid: null,
 };
 
 class AccordionItemWrapper extends Component<AccordionItemWrapperProps> {
@@ -31,13 +33,18 @@ class AccordionItemWrapper extends Component<AccordionItemWrapperProps> {
         return (
             <Provider inject={[this.itemContainer]}>
                 <Subscribe to={[AccordionContainer, ItemContainer]}>
-                    {(accordionStore, itemStore) => (
-                        <AccordionItem
-                            {...this.props}
-                            uuid={itemStore.state.uuid}
-                            accordionStore={accordionStore}
-                        />
-                    )}
+                    {(accordionStore, itemStore) => {
+                        let uuid = itemStore.state.uuid;
+                        if (this.props.uuid) uuid = this.props.uuid;
+                        return (
+                            <AccordionItem
+                                {...this.props}
+                                uuid={uuid}
+                                accordionStore={accordionStore}
+                                itemstore={itemStore}
+                            />
+                        );
+                    }}
                 </Subscribe>
             </Provider>
         );

--- a/src/AccordionItem/accordion-item-wrapper.js
+++ b/src/AccordionItem/accordion-item-wrapper.js
@@ -22,7 +22,7 @@ const defaultProps = {
     disabled: false,
     expanded: false,
     accordionStore: new AccordionContainer(),
-    uuid: null,
+    uuid: undefined,
 };
 
 class AccordionItemWrapper extends Component<AccordionItemWrapperProps> {
@@ -41,7 +41,7 @@ class AccordionItemWrapper extends Component<AccordionItemWrapperProps> {
                                 {...this.props}
                                 uuid={uuid}
                                 accordionStore={accordionStore}
-                                itemstore={itemStore}
+                                itemStore={itemStore}
                             />
                         );
                     }}

--- a/src/AccordionItem/accordion-item.js
+++ b/src/AccordionItem/accordion-item.js
@@ -16,7 +16,18 @@ type AccordionItemProps = ElementProps<'div'> & {
 
 class AccordionItem extends Component<AccordionItemProps, *> {
     componentWillMount() {
-        const { uuid, accordionStore, disabled } = this.props;
+        const { uuid, accordionStore, itemstore, disabled } = this.props;
+
+        itemstore.setUuid(uuid);
+
+        const currentItem = accordionStore.state.items.find(
+            item => item.uuid === uuid,
+        );
+        if (currentItem)
+            // eslint-disable-next-line no-console
+            console.error(
+                `AccordionItem error: One item already has the uuid "${uuid}". Uuid property must be unique. See: https://github.com/springload/react-accessible-accordion#accordionitem`,
+            );
 
         accordionStore.addItem({
             uuid,

--- a/src/AccordionItem/accordion-item.js
+++ b/src/AccordionItem/accordion-item.js
@@ -5,6 +5,7 @@ import type { ElementProps } from 'react';
 
 import classNames from 'classnames';
 import AccordionContainer from '../AccordionContainer/AccordionContainer';
+import ItemContainer from '../ItemContainer/ItemContainer';
 
 type AccordionItemProps = ElementProps<'div'> & {
     uuid: string | number,
@@ -12,13 +13,14 @@ type AccordionItemProps = ElementProps<'div'> & {
     disabled: ?boolean,
     expanded: ?boolean,
     accordionStore: AccordionContainer,
+    itemStore: ItemContainer,
 };
 
 class AccordionItem extends Component<AccordionItemProps, *> {
     componentWillMount() {
-        const { uuid, accordionStore, itemstore, disabled } = this.props;
+        const { uuid, accordionStore, itemStore, disabled } = this.props;
 
-        itemstore.setUuid(uuid);
+        itemStore.setUuid(uuid);
 
         const currentItem = accordionStore.state.items.find(
             item => item.uuid === uuid,
@@ -59,6 +61,7 @@ class AccordionItem extends Component<AccordionItemProps, *> {
             accordionStore,
             disabled,
             expanded,
+            itemStore,
             ...rest
         } = this.props;
 

--- a/src/AccordionItem/accordion-item.spec.js
+++ b/src/AccordionItem/accordion-item.spec.js
@@ -248,31 +248,12 @@ describe('AccordionItem', () => {
             </Provider>,
         );
         resetNextUuid();
-        const wrapperTwo = mount(
-            <Provider inject={[accordionContainer]}>
-                <AccordionItem />
-            </Provider>,
-        );
-        expect(
-            wrapperOne
-                .find(Provider)
-                .last()
-                .props().uuid,
-        ).toEqual(
-            wrapperTwo
-                .find(Provider)
-                .last()
-                .props().uuid,
-        );
-    });
 
-    it('can manually reset the uuid', () => {
-        const wrapperOne = mount(
-            <Provider inject={[accordionContainer]}>
-                <AccordionItem />
-            </Provider>,
-        );
-        resetNextUuid();
+        // Needed to avoid duplicate uuid error
+        accordionContainer = new AccordionContainer();
+        accordionContainer.setAccordion(false);
+        accordionContainer.setOnChange(jest.fn());
+
         const wrapperTwo = mount(
             <Provider inject={[accordionContainer]}>
                 <AccordionItem />
@@ -317,5 +298,45 @@ describe('AccordionItem', () => {
         );
 
         expect(wrapper.find('div').instance().lang).toEqual('en');
+    });
+
+    it('supports custom uuid', () => {
+        const uuid = 'uniqueCustomID';
+        mount(
+            <Provider inject={[accordionContainer]}>
+                <AccordionItem uuid={uuid}>
+                    <AccordionItemTitle>
+                        <div>Fake title</div>
+                    </AccordionItemTitle>
+                </AccordionItem>
+            </Provider>,
+        );
+
+        expect(
+            accordionContainer.state.items.filter(item => item.uuid === uuid)
+                .length,
+        ).toEqual(1);
+    });
+
+    it('raises console error in case of duplicate uuid', () => {
+        const uuid = 'uniqueCustomID';
+        jest.spyOn(global.console, 'error');
+        mount(
+            <Provider inject={[accordionContainer]}>
+                <AccordionItem uuid={uuid}>
+                    <AccordionItemTitle>
+                        <div>Fake title</div>
+                    </AccordionItemTitle>
+                </AccordionItem>
+                <AccordionItem uuid={uuid}>
+                    <AccordionItemTitle>
+                        <div>Fake title</div>
+                    </AccordionItemTitle>
+                </AccordionItem>
+            </Provider>,
+        );
+
+        // eslint-disable-next-line no-console
+        expect(console.error).toBeCalled();
     });
 });

--- a/src/ItemContainer/ItemContainer.js
+++ b/src/ItemContainer/ItemContainer.js
@@ -15,6 +15,12 @@ class ItemContainer extends Container<StoreState> {
     state = {
         uuid: nextUuid(),
     };
+
+    setUuid(customUuid: string) {
+        this.setState({
+            uuid: customUuid,
+        });
+    }
 }
 
 export default ItemContainer;

--- a/src/ItemContainer/ItemContainer.spec.js
+++ b/src/ItemContainer/ItemContainer.spec.js
@@ -6,6 +6,14 @@ describe('ItemContainer', () => {
     it('correctly instantiates with all expected methods/state', () => {
         const itemContainer = new ItemContainer();
         expect(itemContainer.state.uuid).toBeDefined();
+        expect(itemContainer.setUuid).toBeDefined();
+    });
+
+    it('correctly sets the value', () => {
+        const itemContainer = new ItemContainer();
+        const uuid = 'uniqueID';
+        itemContainer.setUuid(uuid);
+        expect(itemContainer.state.uuid).toBe(uuid);
     });
 
     it('generated uuids are different', () => {


### PR DESCRIPTION
Should fix https://github.com/springload/react-accessible-accordion/issues/70

@ryami333 I need you review and your opinion on why I can't pass the property `itemStore` spelt like that. React forced me to go to `itemstore` which doesn't make any sense compared to what we already do with `accordionStore`

See https://github.com/springload/react-accessible-accordion/compare/feature/onchange-informative?expand=1#diff-c47d31ed908c8398ba711632d9294191R44
If you try to modify this by `itemStore` you'll get the React warning in the console.

Only hint I found was: https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html
All custom attributes should be lowercase since React 16?!