### PR TITLE
Fix/regenerator runtime

### DIFF
--- a/src/AccordionItem/accordion-item.js
+++ b/src/AccordionItem/accordion-item.js
@@ -15,7 +15,7 @@ type AccordionItemProps = ElementProps<'div'> & {
 };
 
 class AccordionItem extends Component<AccordionItemProps, *> {
-    async componentDidMount() {
+    componentDidMount() {
         const { uuid, accordionStore, disabled } = this.props;
 
         accordionStore.addItem({

--- a/src/AccordionItemTitle/accordion-item-title.js
+++ b/src/AccordionItemTitle/accordion-item-title.js
@@ -16,23 +16,25 @@ class AccordionItemTitle extends Component<
 > {
     static accordionElementName = 'AccordionItemTitle';
 
-    handleClick = async () => {
+    handleClick = () => {
         const { uuid, accordionStore } = this.props;
         const { state } = accordionStore;
         const { accordion, onChange, items } = state;
         const foundItem = items.find(item => item.uuid === uuid);
 
-        await accordionStore.setExpanded(foundItem.uuid, !foundItem.expanded);
-
-        if (accordion) {
-            onChange(foundItem.uuid);
-        } else {
-            onChange(
-                accordionStore.state.items
-                    .filter(item => item.expanded)
-                    .map(item => item.uuid),
-            );
-        }
+        accordionStore
+            .setExpanded(foundItem.uuid, !foundItem.expanded)
+            .then(() => {
+                if (accordion) {
+                    onChange(foundItem.uuid);
+                } else {
+                    onChange(
+                        accordionStore.state.items
+                            .filter(item => item.expanded)
+                            .map(item => item.uuid),
+                    );
+                }
+            });
     };
 
     handleKeyPress = (evt: SyntheticKeyboardEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
Bit of an urgent fix here - we started using await/async when we upgrade to latest version of `unstated` in 2.0.1 but we didn't include a regeneratorRuntime in the bundle. This affects people whose babel config does not transpile await/async themselves. Will look into best way to do add a runtime to the bundle, but the easiest way to patch for now is to just remove async/await from source.

Closes https://github.com/springload/react-accessible-accordion/issues/93.