### PR TITLE
Remove redundant test in accordion-item-title and accordion-item-body

### DIFF
--- a/src/AccordionItemBody/accordion-item-body.spec.js
+++ b/src/AccordionItemBody/accordion-item-body.spec.js
@@ -61,21 +61,6 @@ describe('AccordionItemBody', () => {
         expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(true);
     });
 
-    it('renders null if an associated AccordionItem is not registered in accordionStore', () => {
-        const className = 'className';
-        const wrapper = mount(
-            <Provider inject={[accordionStore, itemStore]}>
-                <AccordionItemBody className={className}>
-                    <div>Fake body</div>
-                </AccordionItemBody>
-            </Provider>,
-        );
-
-        expect(
-            wrapper.findWhere(item => item.className === className).length,
-        ).toEqual(0);
-    });
-
     it('respects arbitrary user-defined props', () => {
         const wrapper = mount(
             <Provider inject={[accordionStore, itemStore]}>

--- a/src/AccordionItemTitle/accordion-item-title.spec.js
+++ b/src/AccordionItemTitle/accordion-item-title.spec.js
@@ -140,21 +140,6 @@ describe('AccordionItemTitle', () => {
         expect(setExpandedSpy).not.toHaveBeenCalled();
     });
 
-    it('renders null if an associated AccordionItem is not registered in accordionContainer', () => {
-        const className = 'className';
-        const wrapper = mount(
-            <Provider inject={[accordionContainer, itemContainer]}>
-                <AccordionItemTitle className={className}>
-                    <div>Fake body</div>
-                </AccordionItemTitle>
-            </Provider>,
-        );
-
-        expect(
-            wrapper.findWhere(item => item.className === className).length,
-        ).toEqual(0);
-    });
-
     it('respects arbitrary user-defined props', () => {
         const wrapper = mount(
             <Provider inject={[accordionContainer, itemContainer]}>


### PR DESCRIPTION
The following line in these tests was invalid:
```jsx
    wrapper.findWhere(item => item.className === className)
```
Because className is not a property of ReactWrapper. However, while trying to resolve this it became apparent that this test is now a little redundant because `AccordionItemTitle` and `AccordionItemBody` because descendants of `AccordionItem` will never even be rendered until the item has been registered in the accordionContainer.