### PR TITLE
Chore/shift onchange

### DIFF
--- a/src/AccordionContainer/AccordionContainer.js
+++ b/src/AccordionContainer/AccordionContainer.js
@@ -92,7 +92,17 @@ class AccordionContainer extends Container<StoreState> {
                 }
                 return item;
             }),
-        }));
+        })).then(() => {
+            if (this.state.accordion) {
+                this.state.onChange(key);
+            } else {
+                this.state.onChange(
+                    this.state.items
+                        .filter(item => item.expanded)
+                        .map(item => item.uuid),
+                );
+            }
+        });
     }
 }
 

--- a/src/AccordionContainer/AccordionContainer.spec.js
+++ b/src/AccordionContainer/AccordionContainer.spec.js
@@ -253,4 +253,26 @@ describe('Accordion', () => {
         // eslint-disable-next-line no-console
         expect(console.error).toBeCalled();
     });
+
+    it('triggers "onChange" with uuid when a true accordion', async () => {
+        const uuid = 'foo';
+        const onChange = jest.fn();
+        await container.setAccordion(true);
+        await container.addItem({ uuid, disabled: false, expanded: false });
+        await container.setOnChange(onChange);
+        expect(onChange).not.toHaveBeenCalledWith(uuid);
+        await container.setExpanded(uuid, true);
+        expect(onChange).toHaveBeenCalledWith(uuid);
+    });
+
+    it('triggers "onChange" with array of expanded uuids when not a true accordion', async () => {
+        const uuid = 'foo';
+        const onChange = jest.fn();
+        await container.setAccordion(false);
+        await container.addItem({ uuid, disabled: false, expanded: false });
+        await container.setOnChange(onChange);
+        expect(onChange).not.toHaveBeenCalledWith(uuid);
+        await container.setExpanded(uuid, true);
+        expect(onChange).toHaveBeenCalledWith([uuid]);
+    });
 });

--- a/src/AccordionItemTitle/accordion-item-title.js
+++ b/src/AccordionItemTitle/accordion-item-title.js
@@ -19,22 +19,10 @@ class AccordionItemTitle extends Component<
     handleClick = () => {
         const { uuid, accordionStore } = this.props;
         const { state } = accordionStore;
-        const { accordion, onChange, items } = state;
+        const { items } = state;
         const foundItem = items.find(item => item.uuid === uuid);
 
-        accordionStore
-            .setExpanded(foundItem.uuid, !foundItem.expanded)
-            .then(() => {
-                if (accordion) {
-                    onChange(foundItem.uuid);
-                } else {
-                    onChange(
-                        accordionStore.state.items
-                            .filter(item => item.expanded)
-                            .map(item => item.uuid),
-                    );
-                }
-            });
+        accordionStore.setExpanded(foundItem.uuid, !foundItem.expanded);
     };
 
     handleKeyPress = (evt: SyntheticKeyboardEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
Moves 'onChange' behaviour out of `AccordionItemTitle` and into `AccordionContainer`. A precursor PR to a larger piece of work where I'm attempting to make our 'dumb' components 'dumb' and our 'smart' components (ie. the `Wrapper` components) 'smart'.