### PR TITLE
Chore/accordion item title refactor

### DIFF
--- a/src/AccordionContainer/AccordionContainer.js
+++ b/src/AccordionContainer/AccordionContainer.js
@@ -75,8 +75,8 @@ class AccordionContainer extends Container<StoreState> {
         }));
     }
 
-    setExpanded(key: string | number, expanded: boolean) {
-        return this.setState(state => ({
+    setExpanded = (key: string | number, expanded: boolean) =>
+        this.setState(state => ({
             items: state.items.map(item => {
                 if (item.uuid === key) {
                     return {
@@ -103,7 +103,6 @@ class AccordionContainer extends Container<StoreState> {
                 );
             }
         });
-    }
 }
 
 export default AccordionContainer;

--- a/src/AccordionContainer/AccordionContainer.js
+++ b/src/AccordionContainer/AccordionContainer.js
@@ -24,21 +24,21 @@ class AccordionContainer extends Container<StoreState> {
         };
     }
 
-    setAccordion(accordion: boolean) {
+    setAccordion = (accordion: boolean) => {
         if (accordion !== this.state.accordion) {
             return this.setState({ accordion });
         }
         return null;
-    }
+    };
 
-    setOnChange(onChange: Function) {
+    setOnChange = (onChange: Function) => {
         if (onChange !== this.state.onChange) {
             return this.setState({ onChange });
         }
         return null;
-    }
+    };
 
-    addItem(newItem: Item) {
+    addItem = (newItem: Item) => {
         // Need to use callback style otherwise race-conditions are created by concurrent registrations.
         this.setState(state => {
             let items;
@@ -67,13 +67,12 @@ class AccordionContainer extends Container<StoreState> {
                 items,
             };
         });
-    }
+    };
 
-    removeItem(key: string | number) {
-        return this.setState(state => ({
+    removeItem = (key: string | number) =>
+        this.setState(state => ({
             items: state.items.filter(item => item.uuid !== key),
         }));
-    }
 
     setExpanded = (key: string | number, expanded: boolean) =>
         this.setState(state => ({

--- a/src/AccordionItemTitle/accordion-item-title-wrapper.js
+++ b/src/AccordionItemTitle/accordion-item-title-wrapper.js
@@ -27,8 +27,9 @@ const AccordionItemTitleWrapper = (props: AccordionItemTitleWrapperProps) => (
             return (
                 <AccordionItemTitle
                     {...props}
-                    item={item}
-                    accordionStore={accordionStore}
+                    {...item}
+                    setExpanded={accordionStore.setExpanded}
+                    accordion={accordionStore.state.accordion}
                 />
             );
         }}

--- a/src/AccordionItemTitle/accordion-item-title-wrapper.js
+++ b/src/AccordionItemTitle/accordion-item-title-wrapper.js
@@ -19,13 +19,19 @@ type AccordionItemTitleWrapperProps = ElementProps<'div'> & {
 
 const AccordionItemTitleWrapper = (props: AccordionItemTitleWrapperProps) => (
     <Subscribe to={[AccordionContainer, ItemContainer]}>
-        {(accordionStore, itemStore) => (
-            <AccordionItemTitle
-                {...props}
-                uuid={itemStore.state.uuid}
-                accordionStore={accordionStore}
-            />
-        )}
+        {(accordionStore, itemStore) => {
+            const { uuid } = itemStore.state;
+            const { items } = accordionStore.state;
+            const item = items.find(stateItem => stateItem.uuid === uuid);
+
+            return (
+                <AccordionItemTitle
+                    {...props}
+                    item={item}
+                    accordionStore={accordionStore}
+                />
+            );
+        }}
     </Subscribe>
 );
 AccordionItemTitleWrapper.defaultProps = defaultProps;

--- a/src/AccordionItemTitle/accordion-item-title-wrapper.js
+++ b/src/AccordionItemTitle/accordion-item-title-wrapper.js
@@ -21,7 +21,7 @@ const AccordionItemTitleWrapper = (props: AccordionItemTitleWrapperProps) => (
     <Subscribe to={[AccordionContainer, ItemContainer]}>
         {(accordionStore, itemStore) => {
             const { uuid } = itemStore.state;
-            const { items } = accordionStore.state;
+            const { items, accordion } = accordionStore.state;
             const item = items.find(stateItem => stateItem.uuid === uuid);
 
             return (
@@ -29,7 +29,7 @@ const AccordionItemTitleWrapper = (props: AccordionItemTitleWrapperProps) => (
                     {...props}
                     {...item}
                     setExpanded={accordionStore.setExpanded}
-                    accordion={accordionStore.state.accordion}
+                    accordion={accordion}
                 />
             );
         }}

--- a/src/AccordionItemTitle/accordion-item-title.js
+++ b/src/AccordionItemTitle/accordion-item-title.js
@@ -2,11 +2,14 @@
 
 import React, { Component, type ElementProps } from 'react';
 import classNames from 'classnames';
-import { type Item } from '../AccordionContainer/AccordionContainer';
 
 type AccordionItemTitleProps = ElementProps<'div'> & {
     hideBodyClassName: string,
-    item: Item,
+    expanded: boolean,
+    uuid: string | number,
+    disabled: boolean,
+    accordion: boolean,
+    setExpanded: (string | number, boolean) => any,
 };
 
 type AccordionItemTitleState = {};
@@ -18,9 +21,9 @@ class AccordionItemTitle extends Component<
     static accordionElementName = 'AccordionItemTitle';
 
     handleClick = () => {
-        const { item, accordionStore } = this.props;
+        const { uuid, expanded, setExpanded } = this.props;
 
-        accordionStore.setExpanded(item.uuid, !item.expanded);
+        setExpanded(uuid, !expanded);
     };
 
     handleKeyPress = (evt: SyntheticKeyboardEvent<HTMLButtonElement>) => {
@@ -32,16 +35,17 @@ class AccordionItemTitle extends Component<
 
     render() {
         const {
-            state: { accordion },
-        } = this.props.accordionStore;
-        const {
             className,
             hideBodyClassName,
             accordionStore,
             item,
+            accordion,
+            setExpanded,
+            expanded,
+            uuid,
+            disabled,
             ...rest
         } = this.props;
-        const { uuid, expanded, disabled } = item;
 
         const id = `accordion__title-${uuid}`;
         const ariaControls = `accordion__body-${uuid}`;

--- a/src/AccordionItemTitle/accordion-item-title.js
+++ b/src/AccordionItemTitle/accordion-item-title.js
@@ -2,10 +2,11 @@
 
 import React, { Component, type ElementProps } from 'react';
 import classNames from 'classnames';
+import { type Item } from '../AccordionContainer/AccordionContainer';
 
 type AccordionItemTitleProps = ElementProps<'div'> & {
     hideBodyClassName: string,
-    uuid: string | number,
+    item: Item,
 };
 
 type AccordionItemTitleState = {};
@@ -17,12 +18,9 @@ class AccordionItemTitle extends Component<
     static accordionElementName = 'AccordionItemTitle';
 
     handleClick = () => {
-        const { uuid, accordionStore } = this.props;
-        const { state } = accordionStore;
-        const { items } = state;
-        const foundItem = items.find(item => item.uuid === uuid);
+        const { item, accordionStore } = this.props;
 
-        accordionStore.setExpanded(foundItem.uuid, !foundItem.expanded);
+        accordionStore.setExpanded(item.uuid, !item.expanded);
     };
 
     handleKeyPress = (evt: SyntheticKeyboardEvent<HTMLButtonElement>) => {
@@ -34,18 +32,16 @@ class AccordionItemTitle extends Component<
 
     render() {
         const {
-            state: { items, accordion },
+            state: { accordion },
         } = this.props.accordionStore;
         const {
-            uuid,
             className,
             hideBodyClassName,
             accordionStore,
+            item,
             ...rest
         } = this.props;
-        const foundItem = items.find(item => item.uuid === uuid);
-
-        const { expanded, disabled } = foundItem;
+        const { uuid, expanded, disabled } = item;
 
         const id = `accordion__title-${uuid}`;
         const ariaControls = `accordion__body-${uuid}`;


### PR DESCRIPTION
An effort to shift all of the store/container logic to the 'wrapper' and let the 'dumb' component deal only with UI and interaction. So basically, the wrapper passes it all of the props that it needs, no more, no less.

Does not require a release because there is no user-land changes.

Will move on to accordion-item-body