### PR TITLE
Chore/ie11 compat

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,17 @@
+{
+    "presets": [
+        [
+            "env",
+            {
+                "modules": false
+            }
+        ],
+        "react",
+        "stage-2"
+    ],
+    "env": {
+        "test": {
+            "presets": ["env", "react", "stage-2"]
+        }
+    }
+}

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,6 @@
+ie 11
+last 2 chrome versions
+last 2 firefox versions
+last 2 edge versions
+last 2 safari versions
+last 2 ios versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 *   Fixes issue with spacebar scrolling the page (see PR#99)
+*   Fixes IE compatibility by replacing uses of Array.prototype.find.
 
 ## [[v2.4.2]](https://github.com/springload/react-accessible-accordion/releases/tag/v2.4.2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1379,6 +1379,62 @@
         }
       }
     },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.3",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000851",
+            "electron-to-chromium": "1.3.48"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.48",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+          "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
@@ -2056,6 +2112,12 @@
       "version": "1.0.30000810",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000810.tgz",
       "integrity": "sha1-vSWDDEHvq2Qzmi44H0lnc0PIRQk=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000851",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000851.tgz",
+      "integrity": "sha512-Y1ecA1cL9wg0vni8t33nBw/poX8ypm+2c3fbwAESj8cm4ufK9CBFQ1+nUK8Dp5dtFo5Fc3JzkI5DKmQbuIo6hQ==",
       "dev": true
     },
     "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "build:css": "cp src/css/*.css dist",
     "build:clean": "rm -rf dist/*",
-    "build:rollup": "NODE_ENV=production rollup -c",
+    "build:rollup": "rollup -c",
     "build:flow": "flow-copy-source src dist/es -i \"**/*.spec.js\"",
     "build":
       "npm run build:clean && npm run build:css && npm run build:flow && npm run build:rollup",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "build:clean": "rm -rf dist/*",
     "build:rollup": "NODE_ENV=production rollup -c",
     "build:flow": "flow-copy-source src dist/es -i \"**/*.spec.js\"",
-    "build": "npm run build:clean && npm run build:css && npm run build:flow && npm run build:rollup",
+    "build":
+      "npm run build:clean && npm run build:css && npm run build:flow && npm run build:rollup",
     "start": "npm run js:watch",
     "start-demo": "webpack-dev-server --mode=development",
-    "pages": "rm -rf pages && webpack --mode=production --progress && cp demo/*.css pages && cp demo/*.ico pages",
+    "pages":
+      "rm -rf pages && webpack --mode=production --progress && cp demo/*.css pages && cp demo/*.ico pages",
     "deploy": "npm run pages && ./bin/deploy.sh",
     "prettier": "prettier **/*.js --write",
     "prepublishOnly": "npm run build"
@@ -27,36 +29,10 @@
     "type": "git",
     "url": "git+https://github.com/springload/react-accessible-accordion.git"
   },
-  "babel": {
-    "presets": [
-      [
-        "env",
-        {
-          "modules": false
-        }
-      ],
-      "react",
-      "stage-2"
-    ],
-    "env": {
-      "test": {
-        "presets": [
-          "env",
-          "react",
-          "stage-2"
-        ]
-      }
-    }
-  },
   "jest": {
-    "setupFiles": [
-      "./src/setupTests.js"
-    ],
+    "setupFiles": ["./src/setupTests.js"],
     "setupTestFrameworkScriptFile": "./src/setupTestFramework.js",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/dist/"
-    ]
+    "testPathIgnorePatterns": ["/node_modules/", "/dist/"]
   },
   "keywords": [
     "react",
@@ -66,9 +42,7 @@
     "accessible",
     "accessibility"
   ],
-  "authors": [
-    "Vincent Audebert <vincent@springload.co.nz>"
-  ],
+  "authors": ["Vincent Audebert <vincent@springload.co.nz>"],
   "contributors": [
     {
       "name": "Mitch Ryan",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "babel": {
     "presets": [
       [
-        "es2015",
+        "env",
         {
           "modules": false
         }
@@ -41,7 +41,7 @@
     "env": {
       "test": {
         "presets": [
-          "es2015",
+          "env",
           "react",
           "stage-2"
         ]
@@ -92,7 +92,7 @@
     "babel-jest": "^23.0.1",
     "babel-loader": "^7.1.4",
     "babel-polyfill": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "coveralls": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,9 @@ export default [
         ],
         name: 'reactAccessibleAccordion',
         plugins: [
+            replace({
+                'process.env.NODE_ENV': JSON.stringify('production'),
+            }),
             resolve({
                 jsnext: true,
                 main: true,
@@ -23,10 +26,6 @@ export default [
             eslint(),
             babel(),
             commonjs(),
-            replace({
-                exclude: 'node_modules/**',
-                ENV: JSON.stringify(process.env.NODE_ENV || 'development'),
-            }),
         ],
     },
 ];

--- a/src/AccordionItem/accordion-item.js
+++ b/src/AccordionItem/accordion-item.js
@@ -48,9 +48,9 @@ class AccordionItem extends Component<AccordionItemProps, *> {
             ...rest
         } = this.props;
 
-        const currentItem = accordionStore.state.items.find(
+        const currentItem = accordionStore.state.items.filter(
             item => item.uuid === uuid,
-        );
+        )[0];
 
         if (!currentItem) {
             return null;

--- a/src/AccordionItemBody/accordion-item-body.js
+++ b/src/AccordionItemBody/accordion-item-body.js
@@ -19,7 +19,7 @@ const AccordionItemBody = (props: AccordionItemBodyProps) => {
     const {
         state: { items, accordion },
     } = props.accordionStore;
-    const foundItem = items.find(item => item.uuid === uuid);
+    const foundItem = items.filter(item => item.uuid === uuid)[0];
 
     const { expanded } = foundItem;
     const id = `accordion__body-${uuid}`;

--- a/src/AccordionItemTitle/accordion-item-title-wrapper.js
+++ b/src/AccordionItemTitle/accordion-item-title-wrapper.js
@@ -22,7 +22,7 @@ const AccordionItemTitleWrapper = (props: AccordionItemTitleWrapperProps) => (
         {(accordionStore, itemStore) => {
             const { uuid } = itemStore.state;
             const { items, accordion } = accordionStore.state;
-            const item = items.find(stateItem => stateItem.uuid === uuid);
+            const item = items.filter(stateItem => stateItem.uuid === uuid)[0];
 
             return (
                 <AccordionItemTitle


### PR DESCRIPTION
Replaces all uses of `array.find(func)` with `array.filter(func)[0]` for IE11 compatibility.

Also took this opportunity to replace deprecated `babel-preset-es2015` with `babel-preset-env` (effectively same thing), added `.browserslistrc` which was missing, and fixed use of `rollup-plugin-replace` to shave 30kb of the bundle size.