### PR TITLE
Shift the development-related stuff out of README and into CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+## Development
+
+### Install
+
+> Clone the project on your computer, and install [Node](https://nodejs.org). This project also uses [nvm](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#nvm).
+
+```sh
+nvm install
+# Then, install all project dependencies.
+npm install
+# Install the git hooks.
+./.githooks/deploy
+# Set up a `.env` file with the appropriate secrets.
+touch .env
+```
+
+### Working on the project
+
+> Everything mentioned in the installation process should already be done.
+
+```sh
+# Make sure you use the right node version.
+nvm use
+# Start the the development tools in watch mode.
+npm run start
+# Runs linting.
+npm run lint
+# Runs tests.
+npm run test
+# View other available commands with:
+npm run
+```
+
+### Run the demo
+
+> Everything mentioned in the installation process should already be done.
+
+```sh
+# Make sure you use the right node version.
+nvm use
+# Start the server and the development tools.
+npm run start-demo
+```
+
+### Publish
+
+```sh
+npm version [TYPE]
+git push origin master --tags
+npm publish
+```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ReactDOM.render(<Example />, document.querySelector('[data-mount]'));
 ### Styles
 
 We strongly encourage you to write your own styles for your accordions, but we've published these two starter stylesheets to help you get up and running:
+
 ```js
 // 'Minimal' theme - hide/show the AccordionBody component:
 import 'react-accessible-accordion/dist/minimal-example.css';
@@ -229,10 +230,10 @@ This project manages two types of Accordions, with single or multiple items open
 
 For this type of Accordion, you will get the following `role` set up on your elements:
 
-* Accordion: `tablist`
-* AccordionItem: no specific role
-* AccordionItemTitle: `tab`
-* AccordionItemBody: `tabpanel`
+*   Accordion: `tablist`
+*   AccordionItem: no specific role
+*   AccordionItemTitle: `tab`
+*   AccordionItemBody: `tabpanel`
 
 #### Multiple items
 
@@ -240,62 +241,10 @@ For this type of Accordion, you will get the following `role` set up on your ele
 
 > Use this with with props `accordion` set to `false` on `Accordion`.
 
-* Accordion: no specific role
-* AccordionItem: no specific role
-* AccordionItemTitle: `button`
-* AccordionItemBody: no specific role
-
-## Development
-
-### Install
-
-> Clone the project on your computer, and install [Node](https://nodejs.org). This project also uses [nvm](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#nvm).
-
-```sh
-nvm install
-# Then, install all project dependencies.
-npm install
-# Install the git hooks.
-./.githooks/deploy
-# Set up a `.env` file with the appropriate secrets.
-touch .env
-```
-
-### Working on the project
-
-> Everything mentioned in the installation process should already be done.
-
-```sh
-# Make sure you use the right node version.
-nvm use
-# Start the the development tools in watch mode.
-npm run start
-# Runs linting.
-npm run lint
-# Runs tests.
-npm run test
-# View other available commands with:
-npm run
-```
-
-### Run the demo
-
-> Everything mentioned in the installation process should already be done.
-
-```sh
-# Make sure you use the right node version.
-nvm use
-# Start the server and the development tools.
-npm run start-demo
-```
-
-### Publish
-
-```sh
-npm version [TYPE]
-git push origin master --tags
-npm publish
-```
+*   Accordion: no specific role
+*   AccordionItem: no specific role
+*   AccordionItemTitle: `button`
+*   AccordionItemBody: no specific role
 
 # Browser support
 


### PR DESCRIPTION
Just a cut+paste job of the development-specific stuff into a dedicated document. All the other changes are `prettier`-induced formatting changes