### PR TITLE
Replaced ".filter(…)[0]" with ".find(…)"

### DIFF
--- a/src/AccordionItem/AccordionItem.js
+++ b/src/AccordionItem/AccordionItem.js
@@ -48,9 +48,9 @@ class AccordionItem extends Component<AccordionItemProps, *> {
             ...rest
         } = this.props;
 
-        const currentItem = accordionStore.state.items.filter(
+        const currentItem = accordionStore.state.items.find(
             item => item.uuid === uuid,
-        )[0];
+        );
 
         if (!currentItem) {
             return null;

--- a/src/AccordionItemBody/AccordionItemBody.wrapper.js
+++ b/src/AccordionItemBody/AccordionItemBody.wrapper.js
@@ -26,7 +26,7 @@ class AccordionItemBodyWrapper extends Component<
     ) => {
         const { uuid } = itemStore.state;
         const { items, accordion } = accordionStore.state;
-        const item = items.filter(stateItem => stateItem.uuid === uuid)[0];
+        const item = items.find(stateItem => stateItem.uuid === uuid);
         return (
             <AccordionItemBody
                 {...this.props}

--- a/src/AccordionItemTitle/AccordionItemTitle.wrapper.js
+++ b/src/AccordionItemTitle/AccordionItemTitle.wrapper.js
@@ -26,7 +26,7 @@ class AccordionItemTitleWrapper extends Component<
     ) => {
         const { uuid } = itemStore.state;
         const { items, accordion } = accordionStore.state;
-        const item = items.filter(stateItem => stateItem.uuid === uuid)[0];
+        const item = items.find(stateItem => stateItem.uuid === uuid);
 
         return (
             <AccordionItemTitle


### PR DESCRIPTION
Just a very small thing, I stumbled upon a few `.filter(…)[0]` methods that could be rewritten using `.find(…)`.

I named the branch "chore" although I'm not sure if there's a more appropriate name.