### PR TITLE
feat(dynamic-disable): added dynamic disabling of the accordion.

### DIFF
--- a/src/AccordionContainer/AccordionContainer.js
+++ b/src/AccordionContainer/AccordionContainer.js
@@ -26,6 +26,8 @@ export type AccordionContainer = {
     addItem: Item => void,
     removeItem: UUID => void,
     setExpanded: (key: UUID, expanded: boolean) => void,
+    setDisabled: (key: string | number, disabled: boolean) => void,
+
 };
 
 export type ConsumerProps = {
@@ -52,6 +54,7 @@ export class Provider extends Component<ProviderProps, ProviderState> {
             addItem: this.addItem,
             removeItem: this.removeItem,
             setExpanded: this.setExpanded,
+            setDisabled: this.setDisabled,
         };
 
         return {
@@ -130,6 +133,20 @@ export class Provider extends Component<ProviderProps, ProviderState> {
 
     render() {
         return this.props.children || null;
+    }
+
+    setDisabled = (key: string | number, disabled: boolean) => {
+        this.setState(state => ({
+            items: state.items.map(item => {
+                if (item.uuid === key) {
+                    return {
+                        ...item,
+                        disabled,
+                    };
+                }
+                return item;
+            }),
+        }))
     }
 }
 

--- a/src/AccordionContainer/AccordionContainer.spec.js
+++ b/src/AccordionContainer/AccordionContainer.spec.js
@@ -37,6 +37,7 @@ describe('Accordion', () => {
             addItem: expect.anything(),
             removeItem: expect.anything(),
             setExpanded: expect.anything(),
+            setDisabled: expect.anything(),
         });
     });
 

--- a/src/AccordionItem/AccordionItem.js
+++ b/src/AccordionItem/AccordionItem.js
@@ -30,9 +30,13 @@ class AccordionItem extends Component<AccordionItemProps> {
 
     // This is here so that the user can dynamically set the 'expanded' state using the 'expanded' prop.
     componentDidUpdate(prevProps: AccordionItemProps) {
-        const { uuid, expanded, accordionStore } = this.props;
+        const { uuid, expanded, disabled, accordionStore } = this.props;
         if (expanded !== prevProps.expanded) {
             accordionStore.setExpanded(uuid, expanded);
+        }
+
+        if (disabled !== prevProps.disabled) {
+            accordionStore.setDisabled(uuid, disabled);
         }
     }
 

--- a/src/AccordionItem/AccordionItem.spec.js
+++ b/src/AccordionItem/AccordionItem.spec.js
@@ -174,6 +174,29 @@ describe('AccordionItem', () => {
         ).toEqual(1);
     });
 
+    it('can dynamically set disabled prop', async () => {
+        const Wrapper = ({ disabled }: { disabled: boolean }) => (
+            <AccordionProvider>
+                <AccordionItem disabled={disabled}>
+                    <AccordionItemTitle>
+                        <div>Fake title</div>
+                    </AccordionItemTitle>
+                </AccordionItem>
+            </AccordionProvider>
+        );
+
+        const wrapper = await mount(<Wrapper disabled={false} />);
+        wrapper.setProps({ disabled: true });
+
+        expect(
+            wrapper
+                .find(AccordionProvider)
+                .instance().state.items.filter(
+                    item => item.disabled === true,
+                ).length,
+        ).toEqual(1);
+    });
+
     it('can dynamically unset expanded prop', () => {
         const Wrapper = ({ expanded }: { expanded: boolean }) => (
             <AccordionProvider>


### PR DESCRIPTION
I have added a completion of the disable feature on the accordions. My problem was that I wanted to dynamically enable and disable the accordion items and it was not possible: if once set to enabled or disabled it would not react to the disable prop being updated.

Added test for it.