### PR TITLE
Remove ARIA tab roles from accordion

### DIFF
--- a/src/Accordion/Accordion.spec.tsx
+++ b/src/Accordion/Accordion.spec.tsx
@@ -10,16 +10,6 @@ import { default as AccordionItemTitle } from '../AccordionItemTitle/AccordionIt
 import { default as Accordion } from './Accordion.wrapper';
 
 describe('Accordion', () => {
-    it('renders correctly with min params', () => {
-        const wrapper = mount(<Accordion />);
-        expect(wrapper.find('div').props().role).toEqual('tablist');
-    });
-
-    it('renders correctly with accordion false', () => {
-        const wrapper = mount(<Accordion accordion={false} />);
-        expect(wrapper.find('div').props().role).toBeUndefined();
-    });
-
     it('different className', () => {
         const wrapper = mount(<Accordion className="testCSSClass" />);
         expect(wrapper.find('div').props().className).toEqual('testCSSClass');
@@ -245,13 +235,5 @@ describe('Accordion', () => {
         const div = wrapper.find('div').getDOMNode();
 
         expect(div.getAttribute('lang')).toEqual('en');
-    });
-
-    it('renders correctly after update', () => {
-        const wrapper = mount(<Accordion accordion={false} />);
-        expect(wrapper.find('div').props().role).toBeUndefined();
-
-        wrapper.setProps({ accordion: true });
-        expect(wrapper.find('div').props().role).toEqual('tablist');
     });
 });

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
-type AccordionProps = React.HTMLAttributes<HTMLDivElement> & {
-    accordion: boolean;
-};
+type AccordionProps = React.HTMLAttributes<HTMLDivElement>;
 
-const Accordion = ({ accordion, ...rest }: AccordionProps): JSX.Element => {
+const Accordion = ({ ...rest }: AccordionProps): JSX.Element => {
     return <div {...rest} />;
 };
 

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -5,9 +5,7 @@ type AccordionProps = React.HTMLAttributes<HTMLDivElement> & {
 };
 
 const Accordion = ({ accordion, ...rest }: AccordionProps): JSX.Element => {
-    const role = accordion ? 'tablist' : undefined;
-
-    return <div role={role} {...rest} />;
+    return <div {...rest} />;
 };
 
 export default Accordion;

--- a/src/Accordion/Accordion.wrapper.tsx
+++ b/src/Accordion/Accordion.wrapper.tsx
@@ -33,7 +33,7 @@ export default class AccordionWrapper extends React.Component<
     renderAccordion = (accordionStore: AccordionContainer): JSX.Element => {
         const { accordion, onChange, ...rest } = this.props;
 
-        return <Accordion accordion={accordionStore.accordion} {...rest} />;
+        return <Accordion {...rest} />;
     };
 
     render(): JSX.Element {

--- a/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
+++ b/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
@@ -38,12 +38,12 @@ exports[`AccordionItem renders correctly with accordion true 1`] = `
 >
   <div
     aria-controls="accordion__body-0"
-    aria-selected={false}
+    aria-expanded={false}
     className="accordion__title"
     id="accordion__title-0"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="tab"
+    role="button"
     tabIndex={0}
   >
     <div>
@@ -51,11 +51,11 @@ exports[`AccordionItem renders correctly with accordion true 1`] = `
     </div>
   </div>
   <div
-    aria-hidden={true}
+    aria-hidden={null}
     aria-labelledby="accordion__title-0"
     className="accordion__body accordion__body--hidden"
     id="accordion__body-0"
-    role="tabpanel"
+    role="region"
   >
     <div>
       Fake body

--- a/src/AccordionItemBody/AccordionItemBody.tsx
+++ b/src/AccordionItemBody/AccordionItemBody.tsx
@@ -21,7 +21,8 @@ const AccordionItemBody = (props: AccordionItemBodyProps): JSX.Element => {
         ...rest
     } = props;
 
-    const role = accordion ? 'tabpanel' : null;
+    const role = accordion ? 'region' : null;
+    const hideAriaAttribute = accordion ? !expanded : null;
 
     return (
         <div
@@ -29,7 +30,7 @@ const AccordionItemBody = (props: AccordionItemBodyProps): JSX.Element => {
             className={classnames(className, {
                 [hideBodyClassName]: !expanded,
             })}
-            aria-hidden={!expanded}
+            aria-hidden={hideAriaAttribute}
             aria-labelledby={`accordion__title-${uuid}`}
             role={role}
             {...rest}

--- a/src/AccordionItemBody/AccordionItemBody.tsx
+++ b/src/AccordionItemBody/AccordionItemBody.tsx
@@ -22,7 +22,7 @@ const AccordionItemBody = (props: AccordionItemBodyProps): JSX.Element => {
     } = props;
 
     const role = accordion ? 'region' : null;
-    const hideAriaAttribute = accordion ? !expanded : null;
+    const hideAriaAttribute = accordion ? null : !expanded;
 
     return (
         <div

--- a/src/AccordionItemBody/__snapshots__/AccordionItemBody.spec.tsx.snap
+++ b/src/AccordionItemBody/__snapshots__/AccordionItemBody.spec.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`AccordionItemBody renders correctly with min params 1`] = `
 <div
-  aria-hidden={true}
+  aria-hidden={null}
   aria-labelledby="accordion__title-0"
   className="accordion__body accordion__body--hidden"
   id="accordion__body-0"
-  role="tabpanel"
+  role="region"
 >
   <div>
     Fake body

--- a/src/AccordionItemTitle/AccordionItemTitle.tsx
+++ b/src/AccordionItemTitle/AccordionItemTitle.tsx
@@ -44,43 +44,24 @@ export default class AccordionItemTitle extends React.Component<
 
         const id = `accordion__title-${uuid}`;
         const ariaControls = `accordion__body-${uuid}`;
-        const role = accordion ? 'tab' : 'button';
+        const role = 'button';
         const titleClassName = classnames(className, {
             [hideBodyClassName]: hideBodyClassName && !expanded,
         });
         const onClick = disabled ? undefined : this.handleClick;
 
-        switch (role) {
-            case 'tab': {
-                return (
-                    <div
-                        id={id}
-                        aria-selected={expanded}
-                        aria-controls={ariaControls}
-                        className={titleClassName}
-                        onClick={onClick}
-                        role={role}
-                        tabIndex={0}
-                        onKeyPress={this.handleKeyPress}
-                        {...rest}
-                    />
-                );
-            }
-            default: {
-                return (
-                    <div
-                        id={id}
-                        aria-expanded={expanded}
-                        aria-controls={ariaControls}
-                        className={titleClassName}
-                        onClick={onClick}
-                        role={role}
-                        tabIndex={0}
-                        onKeyPress={this.handleKeyPress}
-                        {...rest}
-                    />
-                );
-            }
-        }
+        return (
+            <div
+                id={id}
+                aria-expanded={expanded}
+                aria-controls={ariaControls}
+                className={titleClassName}
+                onClick={onClick}
+                role={role}
+                tabIndex={0}
+                onKeyPress={this.handleKeyPress}
+                {...rest}
+            />
+        );
     }
 }

--- a/src/AccordionItemTitle/AccordionItemTitle.tsx
+++ b/src/AccordionItemTitle/AccordionItemTitle.tsx
@@ -7,7 +7,6 @@ type AccordionItemTitleProps = React.HTMLAttributes<HTMLDivElement> & {
     expanded: boolean;
     uuid: UUID;
     disabled: boolean;
-    accordion: boolean;
     setExpanded(uuid: UUID, expanded: boolean): void;
 };
 
@@ -34,7 +33,6 @@ export default class AccordionItemTitle extends React.Component<
         const {
             className,
             hideBodyClassName,
-            accordion,
             setExpanded,
             expanded,
             uuid,

--- a/src/AccordionItemTitle/AccordionItemTitle.wrapper.tsx
+++ b/src/AccordionItemTitle/AccordionItemTitle.wrapper.tsx
@@ -59,7 +59,7 @@ export default class AccordionItemTitleWrapper extends React.Component<
         }
 
         const { uuid } = itemStore;
-        const { items, accordion } = accordionStore;
+        const { items } = accordionStore;
         const item = items.filter(
             (stateItem: Item) => stateItem.uuid === uuid,
         )[0];
@@ -69,7 +69,6 @@ export default class AccordionItemTitleWrapper extends React.Component<
                 {...this.props}
                 {...item}
                 setExpanded={accordionStore.setExpanded}
-                accordion={accordion}
             />
         );
     }


### PR DESCRIPTION
Hopefully this moves us in the right direction with the accordion. Then maybe we can close both #111 and #30 

Have made base changes according to these specs https://www.w3.org/TR/wai-aria-practices/#accordion

They appear to be slightly different to what they were when we logged #30. Simplified in fact.

I fixed/removed some of the tests, but will need you guys help to further evaluate these changes and make sure I haven't missed anything :)

As a little side note, we don't have the "aria-disabled" option for the accordion because we don't prevent people from being able to close the content. It doesn't appear to be a mandatory thing but probably should flag it so everyone is aware in case it comes up in any future issues.