### PR TITLE
Rename `accordion` prop to `allowMultipleExpanded`

### DIFF
--- a/demo/js/demo.tsx
+++ b/demo/js/demo.tsx
@@ -69,7 +69,7 @@ const Example = (): JSX.Element => (
 
         <h2 className="u-margin-top">Allow multiple</h2>
 
-        <Accordion accordion={false}>
+        <Accordion allowMultipleExpanded={true}>
             <AccordionItem>
                 <AccordionItemHeading>
                     <h3 className="u-position-relative">
@@ -89,9 +89,9 @@ const Example = (): JSX.Element => (
                         </thead>
                         <tbody>
                             <tr>
-                                <td>accordion</td>
+                                <td>allowMultipleExpanded</td>
                                 <td>Boolean</td>
-                                <td>true</td>
+                                <td>false</td>
                                 <td>Open only one item at a time or not</td>
                             </tr>
                             <tr>
@@ -219,7 +219,7 @@ const Example = (): JSX.Element => (
                     </h3>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
-                    <Accordion accordion={false}>
+                    <Accordion allowMultipleExpanded={true}>
                         <AccordionItem>
                             <AccordionItemHeading>
                                 <h3 className="u-position-relative">
@@ -242,9 +242,9 @@ const Example = (): JSX.Element => (
                                     </thead>
                                     <tbody>
                                         <tr>
-                                            <td>accordion</td>
+                                            <td>allowMultipleExpanded</td>
                                             <td>Boolean</td>
-                                            <td>true</td>
+                                            <td>false</td>
                                             <td>
                                                 Open only one item at a time or
                                                 not

--- a/demo/js/demo.tsx
+++ b/demo/js/demo.tsx
@@ -92,7 +92,10 @@ const Example = (): JSX.Element => (
                                 <td>allowMultipleExpanded</td>
                                 <td>Boolean</td>
                                 <td>false</td>
-                                <td>Open only one item at a time or not</td>
+                                <td>
+                                    Don't close all the others when expanding an
+                                    AccordionItem
+                                </td>
                             </tr>
                             <tr>
                                 <td>onChange</td>

--- a/src/Accordion/Accordion.spec.tsx
+++ b/src/Accordion/Accordion.spec.tsx
@@ -15,7 +15,7 @@ describe('Accordion', () => {
         expect(wrapper.find('div').props().className).toEqual('testCSSClass');
     });
 
-    describe('<Accordion accordion="true" />', () => {
+    describe('<Accordion allowMultipleExpanded="false" />', () => {
         const [FooTitle, BarTitle] = [
             (): JSX.Element => <AccordionItemHeading>Foo</AccordionItemHeading>,
             (): JSX.Element => <AccordionItemHeading>Bar</AccordionItemHeading>,
@@ -23,7 +23,7 @@ describe('Accordion', () => {
 
         function mountAccordion(): ReactWrapper {
             return mount(
-                <Accordion accordion={true}>
+                <Accordion allowMultipleExpanded={false}>
                     <AccordionItem>
                         <FooTitle />
                     </AccordionItem>
@@ -80,15 +80,15 @@ describe('Accordion', () => {
         });
     });
 
-    describe('<Accordion accordion="false" /> (‘tabpanel’)', () => {
+    describe('<Accordion allowMultipleExpanded="true" />', () => {
         const [FooTitle, BarTitle] = [
             (): JSX.Element => <AccordionItemHeading>Foo</AccordionItemHeading>,
             (): JSX.Element => <AccordionItemHeading>Bar</AccordionItemHeading>,
         ];
 
-        function mountTabpanel(): ReactWrapper {
+        function mountMultipleExpanded(): ReactWrapper {
             return mount(
-                <Accordion accordion={false}>
+                <Accordion allowMultipleExpanded={true}>
                     <AccordionItem>
                         <FooTitle />
                     </AccordionItem>
@@ -100,7 +100,7 @@ describe('Accordion', () => {
         }
 
         it('expands a collapsed item when its title is clicked', () => {
-            const wrapper = mountTabpanel();
+            const wrapper = mountMultipleExpanded();
 
             wrapper.find(FooTitle).simulate('click');
 
@@ -114,7 +114,7 @@ describe('Accordion', () => {
         });
 
         it("expands a collapsed item when its title is clicked, and doesn't close the others", () => {
-            const wrapper = mountTabpanel();
+            const wrapper = mountMultipleExpanded();
 
             wrapper.find(FooTitle).simulate('click');
             wrapper.find(BarTitle).simulate('click');
@@ -129,7 +129,7 @@ describe('Accordion', () => {
         });
 
         it('collapses an expanded item when its title is clicked', () => {
-            const wrapper = mountTabpanel();
+            const wrapper = mountMultipleExpanded();
 
             wrapper.find(FooTitle).simulate('click'); // open
             wrapper.find(FooTitle).simulate('click'); // close
@@ -144,9 +144,9 @@ describe('Accordion', () => {
         });
     });
 
-    it('does not expanded disabled items on click', () => {
+    it('does not expand disabled items on click', () => {
         const wrapper = mount(
-            <Accordion accordion={false}>
+            <Accordion allowMultipleExpanded={true}>
                 <AccordionItem disabled={true}>
                     <AccordionItemHeading className="foo">
                         Foo Title
@@ -186,7 +186,7 @@ describe('Accordion', () => {
     it('works with multiple pre expanded accordion. Extra expands are just ignored.', () => {
         const hideBodyClassName = 'HIDE';
         const wrapper = mount(
-            <Accordion accordion={true}>
+            <Accordion allowMultipleExpanded={false}>
                 <AccordionItem
                     expanded={true}
                     hideBodyClassName={hideBodyClassName}
@@ -214,9 +214,9 @@ describe('Accordion', () => {
         ).toEqual(1);
     });
 
-    it('pre expanded accordion when accordion is false', () => {
+    it('pre expanded accordion when allowMultipleExpanded is true', () => {
         const wrapper = mount(
-            <Accordion accordion={false}>
+            <Accordion allowMultipleExpanded={true}>
                 <AccordionItem expanded={true}>Fake Child</AccordionItem>
                 <AccordionItem expanded={true}>Fake Child</AccordionItem>
             </Accordion>,

--- a/src/Accordion/Accordion.wrapper.tsx
+++ b/src/Accordion/Accordion.wrapper.tsx
@@ -14,7 +14,7 @@ type AccordionWrapperProps = Omit<
     React.HTMLAttributes<HTMLDivElement>,
     'onChange'
 > & {
-    accordion?: boolean;
+    allowMultipleExpanded?: boolean;
     onChange(args: UUID | UUID[]): void;
 };
 
@@ -22,7 +22,7 @@ export default class AccordionWrapper extends React.Component<
     AccordionWrapperProps
 > {
     static defaultProps: AccordionWrapperProps = {
-        accordion: true,
+        allowMultipleExpanded: false,
         onChange: (): void => {
             //
         },
@@ -31,7 +31,7 @@ export default class AccordionWrapper extends React.Component<
     };
 
     renderAccordion = (accordionStore: AccordionContainer): JSX.Element => {
-        const { accordion, onChange, ...rest } = this.props;
+        const { allowMultipleExpanded, onChange, ...rest } = this.props;
 
         return <Accordion {...rest} />;
     };
@@ -39,7 +39,7 @@ export default class AccordionWrapper extends React.Component<
     render(): JSX.Element {
         return (
             <Provider
-                accordion={this.props.accordion}
+                allowMultipleExpanded={this.props.allowMultipleExpanded}
                 onChange={this.props.onChange}
             >
                 <Consumer>{this.renderAccordion}</Consumer>

--- a/src/AccordionContainer/AccordionContainer.spec.tsx
+++ b/src/AccordionContainer/AccordionContainer.spec.tsx
@@ -122,7 +122,7 @@ describe('Accordion', () => {
         );
     });
 
-    it("adding an expanded item to an accordion that doesn't allow mutliple expansions closes other items", () => {
+    it("adding an expanded item to an accordion that doesn't allow multiple expansions closes other items", () => {
         const mock = jest.fn(() => null);
         const instance = mount(
             <Provider
@@ -385,7 +385,7 @@ describe('Accordion', () => {
         expect(console.error).toBeCalled();
     });
 
-    it("triggers 'onChange' with uuid when accordion doesn't allow mutiple expansions", () => {
+    it("triggers 'onChange' with uuid when accordion doesn't allow multiple expansions", () => {
         const onChange = jest.fn();
         const item = {
             ...DEFAULT_ITEM,

--- a/src/AccordionContainer/AccordionContainer.spec.tsx
+++ b/src/AccordionContainer/AccordionContainer.spec.tsx
@@ -34,7 +34,7 @@ describe('Accordion', () => {
         );
 
         expect(mock).toHaveBeenCalledWith({
-            accordion: false,
+            allowMultipleExpanded: false,
             items: [],
             addItem: expect.anything(),
             removeItem: expect.anything(),
@@ -42,18 +42,18 @@ describe('Accordion', () => {
         });
     });
 
-    it('respects the `accordion` prop', () => {
+    it('respects the `allowMultipleExpanded` prop', () => {
         const mock = jest.fn(() => null);
 
         mount(
-            <Provider accordion={true}>
+            <Provider allowMultipleExpanded={true}>
                 <Consumer>{mock}</Consumer>
             </Provider>,
         );
 
         expect(mock).toHaveBeenCalledWith(
             expect.objectContaining({
-                accordion: true,
+                allowMultipleExpanded: true,
             }),
         );
     });
@@ -122,11 +122,10 @@ describe('Accordion', () => {
         );
     });
 
-    it('adding an expanded item to a strict-accordion closes other items', () => {
+    it("adding an expanded item to an accordion that doesn't allow mutliple expansions closes other items", () => {
         const mock = jest.fn(() => null);
         const instance = mount(
             <Provider
-                accordion={true}
                 items={[{ ...DEFAULT_ITEM, uuid: 'foo', expanded: true }]}
             >
                 <Consumer>{mock}</Consumer>
@@ -149,10 +148,11 @@ describe('Accordion', () => {
         );
     });
 
-    it("adding an expanded item to a non-strict-accordion doesn't close other items", () => {
+    it("adding an expanded item to an accordion that allows multiple expansions doesn't close other items", () => {
         const mock = jest.fn(() => null);
         const instance = mount(
             <Provider
+                allowMultipleExpanded={true}
                 items={[{ ...DEFAULT_ITEM, uuid: 'foo', expanded: true }]}
             >
                 <Consumer>{mock}</Consumer>
@@ -202,7 +202,7 @@ describe('Accordion', () => {
         );
     });
 
-    it('setting the expanded property to true in a strict accordion closes all other items', () => {
+    it("setting the expanded property to true in an accordion that doesn't allow multiple expansions closes all other items", () => {
         const mock = jest.fn(() => null);
         const fooItem = {
             ...DEFAULT_ITEM,
@@ -216,7 +216,7 @@ describe('Accordion', () => {
         };
 
         const instance = mount(
-            <Provider accordion={true} items={[fooItem, barItem]}>
+            <Provider items={[fooItem, barItem]}>
                 <Consumer>{mock}</Consumer>
             </Provider>,
         ).instance() as Provider;
@@ -233,7 +233,7 @@ describe('Accordion', () => {
         );
     });
 
-    it('setting the expanded property to true in a non-strict accordion does not close all other items', () => {
+    it("setting the expanded property to true in an accordion that allows multiple expansions doesn't close all other items", () => {
         const mock = jest.fn(() => null);
         const fooItem = {
             ...DEFAULT_ITEM,
@@ -247,7 +247,7 @@ describe('Accordion', () => {
         };
 
         const instance = mount(
-            <Provider items={[fooItem, barItem]}>
+            <Provider allowMultipleExpanded={true} items={[fooItem, barItem]}>
                 <Consumer>{mock}</Consumer>
             </Provider>,
         ).instance() as Provider;
@@ -328,7 +328,7 @@ describe('Accordion', () => {
             );
         });
 
-        it('can update expanded state of multiple items at the same time', () => {
+        it('can update expanded state of multiple items at the same time in an accordion that allows multiple expansions', () => {
             const mock = jest.fn(() => null);
             const fooItem = {
                 ...DEFAULT_ITEM,
@@ -342,7 +342,10 @@ describe('Accordion', () => {
             };
 
             const instance = mount(
-                <Provider items={[fooItem, barItem]}>
+                <Provider
+                    allowMultipleExpanded={true}
+                    items={[fooItem, barItem]}
+                >
                     <Consumer>{mock}</Consumer>
                 </Provider>,
             ).instance() as Provider;
@@ -382,23 +385,7 @@ describe('Accordion', () => {
         expect(console.error).toBeCalled();
     });
 
-    it('triggers "onChange" with uuid when a true accordion', () => {
-        const onChange = jest.fn();
-        const item = {
-            ...DEFAULT_ITEM,
-            expanded: false,
-        };
-
-        const instance = mount(
-            <Provider accordion={true} items={[item]} onChange={onChange} />,
-        ).instance() as Provider;
-
-        instance.setExpanded(item.uuid, true);
-
-        expect(onChange).toHaveBeenCalledWith(item.uuid);
-    });
-
-    it('triggers "onChange" with array of expanded uuids when not a true accordion', () => {
+    it("triggers 'onChange' with uuid when accordion doesn't allow mutiple expansions", () => {
         const onChange = jest.fn();
         const item = {
             ...DEFAULT_ITEM,
@@ -407,6 +394,26 @@ describe('Accordion', () => {
 
         const instance = mount(
             <Provider items={[item]} onChange={onChange} />,
+        ).instance() as Provider;
+
+        instance.setExpanded(item.uuid, true);
+
+        expect(onChange).toHaveBeenCalledWith(item.uuid);
+    });
+
+    it('triggers "onChange" with array of expanded uuids when accordion allows multiple expansions', () => {
+        const onChange = jest.fn();
+        const item = {
+            ...DEFAULT_ITEM,
+            expanded: false,
+        };
+
+        const instance = mount(
+            <Provider
+                allowMultipleExpanded={true}
+                items={[item]}
+                onChange={onChange}
+            />,
         ).instance() as Provider;
 
         instance.setExpanded(item.uuid, true);

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -81,7 +81,6 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
                 );
             }
             if (!this.props.allowMultipleExpanded && newItem.expanded) {
-                // If this is a true accordion that doesn't allow multiple expansions and the new item is expanded, then the others must be closed.
                 items = [
                     ...state.items.map((item: Item) => ({
                         ...item,

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -18,14 +18,14 @@ export type ProviderState = {
 };
 
 export type ProviderProps = {
-    accordion?: boolean;
+    allowMultipleExpanded?: boolean;
     children?: React.ReactNode;
     items?: Item[];
     onChange?(args: UUID | UUID[]): void;
 };
 
 export type AccordionContainer = {
-    accordion: boolean;
+    allowMultipleExpanded: boolean;
     items: Item[];
     addItem(item: Item): void;
     removeItem(uuid: UUID): void;
@@ -56,7 +56,7 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
     getChildContext(): { [CONTEXT_KEY]: AccordionContainer } {
         const context: AccordionContainer = {
             items: this.state.items,
-            accordion: !!this.props.accordion,
+            allowMultipleExpanded: !!this.props.allowMultipleExpanded,
             addItem: this.addItem,
             removeItem: this.removeItem,
             setExpanded: this.setExpanded,
@@ -80,8 +80,8 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
                     }". Uuid property must be unique. See: https://github.com/springload/react-accessible-accordion#accordionitem`,
                 );
             }
-            if (this.props.accordion && newItem.expanded) {
-                // If this is a true accordion and the new item is expanded, then the others must be closed.
+            if (!this.props.allowMultipleExpanded && newItem.expanded) {
+                // If this is a true accordion that doesn't allow multiple expansions and the new item is expanded, then the others must be closed.
                 items = [
                     ...state.items.map((item: Item) => ({
                         ...item,
@@ -115,8 +115,8 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
                             expanded,
                         };
                     }
-                    if (this.props.accordion && expanded) {
-                        // If this is an accordion, we might need to collapse the other expanded item.
+                    if (!this.props.allowMultipleExpanded && expanded) {
+                        // If this is an accordion that doesn't allow multiple expansions, we might need to collapse the other expanded item.
                         return {
                             ...item,
                             expanded: false,
@@ -129,7 +129,7 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
             () => {
                 if (this.props.onChange) {
                     this.props.onChange(
-                        this.props.accordion
+                        !this.props.allowMultipleExpanded
                             ? key
                             : this.state.items
                                   .filter((item: Item) => item.expanded)

--- a/src/AccordionItem/AccordionItem.spec.tsx
+++ b/src/AccordionItem/AccordionItem.spec.tsx
@@ -20,9 +20,9 @@ describe('AccordionItem', () => {
         expect(wrapper.html()).toBeNull();
     });
 
-    it('renders correctly with accordion true', () => {
+    it('renders correctly with allowMultipleExpanded false', () => {
         const wrapper = mount(
-            <AccordionProvider accordion={true}>
+            <AccordionProvider>
                 <AccordionItem className="accordion__item">
                     <AccordionItemHeading className="accordion__heading">
                         <div>Fake title</div>
@@ -37,9 +37,9 @@ describe('AccordionItem', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('renders correctly with accordion false', () => {
+    it('renders correctly with allowMultipleExpanded true', () => {
         const wrapper = mount(
-            <AccordionProvider>
+            <AccordionProvider allowMultipleExpanded={true}>
                 <AccordionItem className="accordion__item">
                     <AccordionItemHeading className="accordion__heading">
                         <div>Fake title</div>

--- a/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
+++ b/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
@@ -1,38 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AccordionItem renders correctly with accordion false 1`] = `
-<div
-  className="accordion__item"
->
-  <div
-    aria-controls="accordion__panel-0"
-    aria-expanded={false}
-    className="accordion__heading"
-    id="accordion__heading-0"
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    role="button"
-    tabIndex={0}
-  >
-    <div>
-      Fake title
-    </div>
-  </div>
-  <div
-    aria-hidden={true}
-    aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
-    id="accordion__panel-0"
-    role={null}
-  >
-    <div>
-      Fake body
-    </div>
-  </div>
-</div>
-`;
-
-exports[`AccordionItem renders correctly with accordion true 1`] = `
+exports[`AccordionItem renders correctly with allowMultipleExpanded false 1`] = `
 <div
   className="accordion__item"
 >
@@ -64,6 +32,38 @@ exports[`AccordionItem renders correctly with accordion true 1`] = `
 </div>
 `;
 
+exports[`AccordionItem renders correctly with allowMultipleExpanded true 1`] = `
+<div
+  className="accordion__item"
+>
+  <div
+    aria-controls="accordion__panel-0"
+    aria-expanded={false}
+    className="accordion__heading"
+    id="accordion__heading-0"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    <div>
+      Fake title
+    </div>
+  </div>
+  <div
+    aria-hidden={true}
+    aria-labelledby="accordion__heading-0"
+    className="accordion__panel accordion__panel--hidden"
+    id="accordion__panel-0"
+    role={null}
+  >
+    <div>
+      Fake body
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AccordionItem renders correctly with other blocks inside 1`] = `
 <div
   className="accordion__item"
@@ -86,11 +86,11 @@ exports[`AccordionItem renders correctly with other blocks inside 1`] = `
     Just another block
   </div>
   <div
-    aria-hidden={true}
+    aria-hidden={null}
     aria-labelledby="accordion__heading-0"
     className="accordion__panel accordion__panel--hidden"
     id="accordion__panel-0"
-    role={null}
+    role="region"
   >
     <div>
       Fake body
@@ -118,11 +118,11 @@ exports[`AccordionItem renders correctly with other blocks inside 2 1`] = `
     </div>
   </div>
   <div
-    aria-hidden={true}
+    aria-hidden={null}
     aria-labelledby="accordion__heading-0"
     className="accordion__panel accordion__panel--hidden"
     id="accordion__panel-0"
-    role={null}
+    role="region"
   >
     <div>
       Fake body

--- a/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
@@ -39,7 +39,7 @@ describe('AccordionItemHeading', () => {
         item: Item = DEFAULT_ITEM,
     ): ReactWrapper {
         return mount(
-            <AccordionProvider accordion={false} items={[item]}>
+            <AccordionProvider allowMultipleExpanded={true} items={[item]}>
                 <ItemProvider uuid={item.uuid}>{node}</ItemProvider>
             </AccordionProvider>,
         );
@@ -152,10 +152,9 @@ describe('AccordionItemHeading', () => {
     });
 
     // edge case to cover branch
-    it('doesn’t toggle state when clicking but disabled & accordion === true', async () => {
+    it('doesn’t toggle state when clicking but disabled & allowMultipleExpanded === false', async () => {
         const wrapper = mount(
             <AccordionProvider
-                accordion={true}
                 items={[
                     {
                         ...DEFAULT_ITEM,

--- a/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
@@ -16,7 +16,7 @@ describe('AccordionItemPanel', () => {
         };
 
         return mount(
-            <AccordionProvider accordion={true} items={[item]}>
+            <AccordionProvider items={[item]}>
                 <ItemProvider uuid={item.uuid}>{children}</ItemProvider>
             </AccordionProvider>,
         );
@@ -66,7 +66,7 @@ describe('AccordionItemPanel', () => {
 
     it('does not render if no itemStore found in context', () => {
         const wrapper = mount(
-            <AccordionProvider accordion={true} items={[]}>
+            <AccordionProvider allowMultipleExpanded={false} items={[]}>
                 <AccordionItemPanel>
                     <div data-enzyme={true}>Hello World</div>
                 </AccordionItemPanel>

--- a/src/AccordionItemPanel/AccordionItemPanel.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.tsx
@@ -7,7 +7,7 @@ type AccordionItemPanelProps = React.HTMLAttributes<HTMLDivElement> & {
     uuid: UUID;
     expanded: boolean;
     disabled: boolean;
-    accordion: boolean;
+    allowMultipleExpanded: boolean;
 };
 
 const AccordionItemPanel = (props: AccordionItemPanelProps): JSX.Element => {
@@ -17,12 +17,12 @@ const AccordionItemPanel = (props: AccordionItemPanelProps): JSX.Element => {
         uuid,
         expanded,
         disabled,
-        accordion,
+        allowMultipleExpanded,
         ...rest
     } = props;
 
-    const role = accordion ? 'region' : null;
-    const hideAriaAttribute = accordion ? null : !expanded;
+    const role = allowMultipleExpanded ? null : 'region';
+    const hideAriaAttribute = allowMultipleExpanded ? !expanded : null;
 
     return (
         <div

--- a/src/AccordionItemPanel/AccordionItemPanel.wrapper.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.wrapper.tsx
@@ -62,7 +62,7 @@ export default class AccordionItemPanelWrapper extends React.Component<
         }
 
         const { uuid } = itemStore;
-        const { items, accordion } = accordionStore;
+        const { items, allowMultipleExpanded } = accordionStore;
         const item = items.filter(
             (stateItem: Item) => stateItem.uuid === uuid,
         )[0];
@@ -71,7 +71,7 @@ export default class AccordionItemPanelWrapper extends React.Component<
             <AccordionItemPanel
                 {...this.props}
                 {...item}
-                accordion={accordion}
+                allowMultipleExpanded={allowMultipleExpanded}
             />
         ) : null;
     }


### PR DESCRIPTION
This should close issue #152 - I've gone through and renamed the `accordion` prop to `allowMultipleExpanded` and also switched the booleans around (so that what used to be `accordion={true}` is now `allowMultipleExpanded={false}`).

Some of the tests also needed fixing up, as they seemed to have been written in keeping with the incorrect default behaviour (where `accordion={false}`/`allowMultipleExpanded={true}` was the default rather than the other way round, as from what I gather we want the default to be a 'strict' accordion that doesn't allow the user to have multiple tabs open at once). I also rewrote the descriptions of some of the tests so they specify whether an accordion allows multiple expansions or not rather than referring to 'strict' or 'non-strict' accordions, as that seemed to be ambiguous in a similar way to the naming of the prop `accordion` rather than `allowMultipleExpanded`.