### PR TITLE
Unify 'onChange' behaviour

### DIFF
--- a/demo/js/demo.tsx
+++ b/demo/js/demo.tsx
@@ -606,9 +606,9 @@ const Example = (): JSX.Element => (
 
         <Accordion
             // tslint:disable-next-line react-this-binding-issue jsx-no-lambda
-            onChange={(itemUuid: string | number): void => {
+            onChange={(itemUuids: (string | number)[]): void => {
                 // tslint:disable-next-line no-console
-                console.log(itemUuid);
+                console.log(itemUuids);
             }}
         >
             <AccordionItem uuid="uniqueItem-1">

--- a/src/Accordion/Accordion.wrapper.tsx
+++ b/src/Accordion/Accordion.wrapper.tsx
@@ -15,7 +15,7 @@ type AccordionWrapperProps = Omit<
     'onChange'
 > & {
     allowMultipleExpanded?: boolean;
-    onChange(args: UUID | UUID[]): void;
+    onChange(args: UUID[]): void;
 };
 
 export default class AccordionWrapper extends React.Component<

--- a/src/AccordionContainer/AccordionContainer.spec.tsx
+++ b/src/AccordionContainer/AccordionContainer.spec.tsx
@@ -385,7 +385,7 @@ describe('Accordion', () => {
         expect(console.error).toBeCalled();
     });
 
-    it("triggers 'onChange' with uuid when accordion doesn't allow multiple expansions", () => {
+    it("triggers 'onChange' with array of expanded uuids when accordion doesn't allow multiple expansions", () => {
         const onChange = jest.fn();
         const item = {
             ...DEFAULT_ITEM,
@@ -398,7 +398,7 @@ describe('Accordion', () => {
 
         instance.setExpanded(item.uuid, true);
 
-        expect(onChange).toHaveBeenCalledWith(item.uuid);
+        expect(onChange).toHaveBeenCalledWith([item.uuid]);
     });
 
     it('triggers "onChange" with array of expanded uuids when accordion allows multiple expansions', () => {

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -21,7 +21,7 @@ export type ProviderProps = {
     allowMultipleExpanded?: boolean;
     children?: React.ReactNode;
     items?: Item[];
-    onChange?(args: UUID | UUID[]): void;
+    onChange?(args: UUID[]): void;
 };
 
 export type AccordionContainer = {
@@ -128,11 +128,9 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
             () => {
                 if (this.props.onChange) {
                     this.props.onChange(
-                        !this.props.allowMultipleExpanded
-                            ? key
-                            : this.state.items
-                                  .filter((item: Item) => item.expanded)
-                                  .map((item: Item) => item.uuid),
+                        this.state.items
+                            .filter((item: Item) => item.expanded)
+                            .map((item: Item) => item.uuid),
                     );
                 }
             },


### PR DESCRIPTION
I've amended the `setExpanded` function so that when the onChange callback is invoked, an array of strings is returned regardless of whether `allowMultipleExpanded === false` or `true`. I've also removed `UUID` as a type of argument accepted by `onChange` and updated the demo accordingly. This should close issue #156. 