### PR TITLE
Feature/allow zero expanded

### DIFF
--- a/demo/js/demo.tsx
+++ b/demo/js/demo.tsx
@@ -67,9 +67,9 @@ const Example = (): JSX.Element => (
             </AccordionItem>
         </Accordion>
 
-        <h2 className="u-margin-top">Allow multiple</h2>
+        <h2 className="u-margin-top">Allow multiple/zero</h2>
 
-        <Accordion allowMultipleExpanded={true}>
+        <Accordion allowMultipleExpanded={true} allowZeroExpanded={true}>
             <AccordionItem>
                 <AccordionItemHeading>
                     <h3 className="u-position-relative">
@@ -95,6 +95,15 @@ const Example = (): JSX.Element => (
                                 <td>
                                     Don't close all the others when expanding an
                                     AccordionItem
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>allowZeroExpanded</td>
+                                <td>Boolean</td>
+                                <td>false</td>
+                                <td>
+                                    Close an AccordionItem when it's the only
+                                    one expanded
                                 </td>
                             </tr>
                             <tr>

--- a/src/Accordion/Accordion.spec.tsx
+++ b/src/Accordion/Accordion.spec.tsx
@@ -23,7 +23,7 @@ describe('Accordion', () => {
 
         function mountAccordion(): ReactWrapper {
             return mount(
-                <Accordion allowMultipleExpanded={false}>
+                <Accordion>
                     <AccordionItem>
                         <FooTitle />
                     </AccordionItem>

--- a/src/Accordion/Accordion.wrapper.tsx
+++ b/src/Accordion/Accordion.wrapper.tsx
@@ -15,6 +15,7 @@ type AccordionWrapperProps = Omit<
     'onChange'
 > & {
     allowMultipleExpanded?: boolean;
+    allowZeroExpanded?: boolean;
     onChange(args: UUID[]): void;
 };
 
@@ -23,6 +24,7 @@ export default class AccordionWrapper extends React.Component<
 > {
     static defaultProps: AccordionWrapperProps = {
         allowMultipleExpanded: false,
+        allowZeroExpanded: false,
         onChange: (): void => {
             //
         },
@@ -31,7 +33,12 @@ export default class AccordionWrapper extends React.Component<
     };
 
     renderAccordion = (accordionStore: AccordionContainer): JSX.Element => {
-        const { allowMultipleExpanded, onChange, ...rest } = this.props;
+        const {
+            allowMultipleExpanded,
+            allowZeroExpanded,
+            onChange,
+            ...rest
+        } = this.props;
 
         return <Accordion {...rest} />;
     };
@@ -40,6 +47,7 @@ export default class AccordionWrapper extends React.Component<
         return (
             <Provider
                 allowMultipleExpanded={this.props.allowMultipleExpanded}
+                allowZeroExpanded={this.props.allowZeroExpanded}
                 onChange={this.props.onChange}
             >
                 <Consumer>{this.renderAccordion}</Consumer>

--- a/src/AccordionContainer/AccordionContainer.spec.tsx
+++ b/src/AccordionContainer/AccordionContainer.spec.tsx
@@ -35,6 +35,7 @@ describe('Accordion', () => {
 
         expect(mock).toHaveBeenCalledWith({
             allowMultipleExpanded: false,
+            allowZeroExpanded: false,
             items: [],
             addItem: expect.anything(),
             removeItem: expect.anything(),

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -19,6 +19,7 @@ export type ProviderState = {
 
 export type ProviderProps = {
     allowMultipleExpanded?: boolean;
+    allowZeroExpanded?: boolean;
     children?: React.ReactNode;
     items?: Item[];
     onChange?(args: UUID[]): void;
@@ -26,6 +27,7 @@ export type ProviderProps = {
 
 export type AccordionContainer = {
     allowMultipleExpanded: boolean;
+    allowZeroExpanded?: boolean;
     items: Item[];
     addItem(item: Item): void;
     removeItem(uuid: UUID): void;
@@ -57,6 +59,7 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
         const context: AccordionContainer = {
             items: this.state.items,
             allowMultipleExpanded: !!this.props.allowMultipleExpanded,
+            allowZeroExpanded: !!this.props.allowZeroExpanded,
             addItem: this.addItem,
             removeItem: this.removeItem,
             setExpanded: this.setExpanded,
@@ -99,9 +102,22 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
     };
 
     removeItem = (key: UUID): void => {
-        this.setState((state: ProviderState) => ({
-            items: state.items.filter((item: Item) => item.uuid !== key),
-        }));
+        this.setState((state: ProviderState) => {
+            let items: Item[];
+
+            if (
+                this.props.allowZeroExpanded ||
+                state.items.filter((item: Item) => item.expanded).length > 1
+            ) {
+                items = state.items.filter((item: Item) => item.uuid !== key);
+            } else {
+                items = state.items;
+            }
+
+            return {
+                items,
+            };
+        });
     };
 
     setExpanded = (key: UUID, expanded: boolean): void => {

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -102,22 +102,9 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
     };
 
     removeItem = (key: UUID): void => {
-        this.setState((state: ProviderState) => {
-            let items: Item[];
-
-            if (
-                !this.props.allowZeroExpanded &&
-                state.items.filter((item: Item) => item.expanded).length < 2
-            ) {
-                items = state.items;
-            } else {
-                items = state.items.filter((item: Item) => item.uuid !== key);
-            }
-
-            return {
-                items,
-            };
-        });
+        this.setState((state: ProviderState) => ({
+            items: state.items.filter((item: Item) => item.uuid !== key),
+        }));
     };
 
     setExpanded = (key: UUID, expanded: boolean): void => {
@@ -125,10 +112,22 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
             (state: ProviderState) => ({
                 items: state.items.map((item: Item) => {
                     if (item.uuid === key) {
-                        return {
-                            ...item,
-                            expanded,
-                        };
+                        if (
+                            !expanded &&
+                            !this.props.allowZeroExpanded &&
+                            state.items.filter((item_: Item) => item_.expanded)
+                                .length < 2
+                        ) {
+                            // If this is an accordion that doesn't allow all items to be closed and the current item is the only one open, don't allow it to close.
+                            return {
+                                ...item,
+                            };
+                        } else {
+                            return {
+                                ...item,
+                                expanded,
+                            };
+                        }
                     }
                     if (!this.props.allowMultipleExpanded && expanded) {
                         // If this is an accordion that doesn't allow multiple expansions, we might need to collapse the other expanded item.

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -106,12 +106,12 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
             let items: Item[];
 
             if (
-                this.props.allowZeroExpanded ||
-                state.items.filter((item: Item) => item.expanded).length > 1
+                !this.props.allowZeroExpanded &&
+                state.items.filter((item: Item) => item.expanded).length < 2
             ) {
-                items = state.items.filter((item: Item) => item.uuid !== key);
-            } else {
                 items = state.items;
+            } else {
+                items = state.items.filter((item: Item) => item.uuid !== key);
             }
 
             return {

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -108,26 +108,22 @@ export class Provider extends React.Component<ProviderProps, ProviderState> {
     };
 
     setExpanded = (key: UUID, expanded: boolean): void => {
+        if (
+            !expanded &&
+            !this.props.allowZeroExpanded &&
+            this.state.items.filter((item: Item) => item.expanded).length === 1
+        ) {
+            // If this is an accordion that doesn't allow all items to be closed and the current item is the only one open, don't allow it to close.
+            return;
+        }
         this.setState(
             (state: ProviderState) => ({
                 items: state.items.map((item: Item) => {
                     if (item.uuid === key) {
-                        if (
-                            !expanded &&
-                            !this.props.allowZeroExpanded &&
-                            state.items.filter((item_: Item) => item_.expanded)
-                                .length < 2
-                        ) {
-                            // If this is an accordion that doesn't allow all items to be closed and the current item is the only one open, don't allow it to close.
-                            return {
-                                ...item,
-                            };
-                        } else {
-                            return {
-                                ...item,
-                                expanded,
-                            };
-                        }
+                        return {
+                            ...item,
+                            expanded,
+                        };
                     }
                     if (!this.props.allowMultipleExpanded && expanded) {
                         // If this is an accordion that doesn't allow multiple expansions, we might need to collapse the other expanded item.

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -27,7 +27,7 @@ export type ProviderProps = {
 
 export type AccordionContainer = {
     allowMultipleExpanded: boolean;
-    allowZeroExpanded?: boolean;
+    allowZeroExpanded: boolean;
     items: Item[];
     addItem(item: Item): void;
     removeItem(uuid: UUID): void;

--- a/src/AccordionItem/AccordionItem.spec.tsx
+++ b/src/AccordionItem/AccordionItem.spec.tsx
@@ -216,9 +216,9 @@ describe('AccordionItem', () => {
         ).toEqual(1);
     });
 
-    it('can dynamically unset expanded prop', () => {
+    it('can dynamically unset expanded prop when there is only one item expanded and allowZeroExpanded is set to true', () => {
         const Wrapper = ({ expanded }: { expanded: boolean }): JSX.Element => (
-            <AccordionProvider>
+            <AccordionProvider allowZeroExpanded={true}>
                 <AccordionItem expanded={expanded}>
                     <AccordionItemHeading>
                         <div>Fake title</div>
@@ -238,6 +238,35 @@ describe('AccordionItem', () => {
             instance.state.items.filter((item: Item) => item.expanded === true)
                 .length,
         ).toEqual(0);
+    });
+
+    it('can dynamically unset expanded prop when there is more than one item expanded', () => {
+        const Wrapper = ({ expanded }: { expanded: boolean }): JSX.Element => (
+            <AccordionProvider>
+                <AccordionItem expanded={expanded}>
+                    <AccordionItemHeading>
+                        <div>Fake title</div>
+                    </AccordionItemHeading>
+                </AccordionItem>
+                <AccordionItem expanded={true}>
+                    <AccordionItemHeading>
+                        <div>Fake title</div>
+                    </AccordionItemHeading>
+                </AccordionItem>
+            </AccordionProvider>
+        );
+
+        const wrapper = mount(<Wrapper expanded={true} />);
+        const instance = wrapper
+            .find(AccordionProvider)
+            .instance() as AccordionProvider;
+
+        wrapper.setProps({ expanded: undefined });
+
+        expect(
+            instance.state.items.filter((item: Item) => item.expanded === true)
+                .length,
+        ).toEqual(1);
     });
 
     it('dynamically changing arbitrary props does not affect expanded state', () => {
@@ -307,35 +336,6 @@ describe('AccordionItem', () => {
         wrapper.setProps({ showChild: false });
 
         expect(instance.state.items.length).toEqual(0);
-    });
-
-    it("doesn't unregister itself on unmount in an accordion that doesn't allow zero items to be expanded", () => {
-        const Wrapper = ({
-            showChild,
-        }: {
-            showChild: boolean;
-        }): JSX.Element => (
-            <AccordionProvider>
-                {showChild && (
-                    <AccordionItem>
-                        <AccordionItemHeading>
-                            <div>Fake title</div>
-                        </AccordionItemHeading>
-                    </AccordionItem>
-                )}
-            </AccordionProvider>
-        );
-
-        const wrapper = mount(<Wrapper showChild={true} />);
-        const instance = wrapper
-            .find(AccordionProvider)
-            .instance() as AccordionProvider;
-
-        expect(instance.state.items.length).toEqual(1);
-
-        wrapper.setProps({ showChild: false });
-
-        expect(instance.state.items.length).toEqual(1);
     });
 
     it('respects arbitrary user-defined props', () => {

--- a/src/AccordionItem/AccordionItem.spec.tsx
+++ b/src/AccordionItem/AccordionItem.spec.tsx
@@ -54,6 +54,40 @@ describe('AccordionItem', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    it('renders correctly with allowZeroExpanded false', () => {
+        const wrapper = mount(
+            <AccordionProvider>
+                <AccordionItem className="accordion__item">
+                    <AccordionItemHeading className="accordion__heading">
+                        <div>Fake title</div>
+                    </AccordionItemHeading>
+                    <AccordionItemPanel className="accordion__panel">
+                        <div>Fake body</div>
+                    </AccordionItemPanel>
+                </AccordionItem>
+            </AccordionProvider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders correctly with allowZeroExpanded true', () => {
+        const wrapper = mount(
+            <AccordionProvider allowZeroExpanded={true}>
+                <AccordionItem className="accordion__item">
+                    <AccordionItemHeading className="accordion__heading">
+                        <div>Fake title</div>
+                    </AccordionItemHeading>
+                    <AccordionItemPanel className="accordion__panel">
+                        <div>Fake body</div>
+                    </AccordionItemPanel>
+                </AccordionItem>
+            </AccordionProvider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     it('renders with multiple AccordionItems', () => {
         const wrapper = mount(
             <AccordionProvider>
@@ -246,7 +280,36 @@ describe('AccordionItem', () => {
         ).toEqual(0);
     });
 
-    it('correctly unregisters itself on unmount', () => {
+    it('correctly unregisters itself on unmount in an accordion that allows zero items to be expanded', () => {
+        const Wrapper = ({
+            showChild,
+        }: {
+            showChild: boolean;
+        }): JSX.Element => (
+            <AccordionProvider allowZeroExpanded={true}>
+                {showChild && (
+                    <AccordionItem>
+                        <AccordionItemHeading>
+                            <div>Fake title</div>
+                        </AccordionItemHeading>
+                    </AccordionItem>
+                )}
+            </AccordionProvider>
+        );
+
+        const wrapper = mount(<Wrapper showChild={true} />);
+        const instance = wrapper
+            .find(AccordionProvider)
+            .instance() as AccordionProvider;
+
+        expect(instance.state.items.length).toEqual(1);
+
+        wrapper.setProps({ showChild: false });
+
+        expect(instance.state.items.length).toEqual(0);
+    });
+
+    it("doesn't unregister itself on unmount in an accordion that doesn't allow zero items to be expanded", () => {
         const Wrapper = ({
             showChild,
         }: {
@@ -272,7 +335,7 @@ describe('AccordionItem', () => {
 
         wrapper.setProps({ showChild: false });
 
-        expect(instance.state.items.length).toEqual(0);
+        expect(instance.state.items.length).toEqual(1);
     });
 
     it('respects arbitrary user-defined props', () => {

--- a/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
+++ b/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
@@ -64,6 +64,70 @@ exports[`AccordionItem renders correctly with allowMultipleExpanded true 1`] = `
 </div>
 `;
 
+exports[`AccordionItem renders correctly with allowZeroExpanded false 1`] = `
+<div
+  className="accordion__item"
+>
+  <div
+    aria-controls="accordion__panel-0"
+    aria-expanded={false}
+    className="accordion__heading"
+    id="accordion__heading-0"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    <div>
+      Fake title
+    </div>
+  </div>
+  <div
+    aria-hidden={null}
+    aria-labelledby="accordion__heading-0"
+    className="accordion__panel accordion__panel--hidden"
+    id="accordion__panel-0"
+    role="region"
+  >
+    <div>
+      Fake body
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionItem renders correctly with allowZeroExpanded true 1`] = `
+<div
+  className="accordion__item"
+>
+  <div
+    aria-controls="accordion__panel-0"
+    aria-expanded={false}
+    className="accordion__heading"
+    id="accordion__heading-0"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    <div>
+      Fake title
+    </div>
+  </div>
+  <div
+    aria-hidden={null}
+    aria-labelledby="accordion__heading-0"
+    className="accordion__panel accordion__panel--hidden"
+    id="accordion__panel-0"
+    role="region"
+  >
+    <div>
+      Fake body
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AccordionItem renders correctly with other blocks inside 1`] = `
 <div
   className="accordion__item"


### PR DESCRIPTION
I've added an `allowZeroExpanded` prop (as outlined in issue #153) that determines whether a 'close' action should be blocked if the item is currently the only one open. By default this prop is set to `false`, but it can be set to `true` in order to enable this functionality. I've also updated and added tests to cover this feature.