### PR TITLE
Remove any mention of undocumented feature 'disabled'

### DIFF
--- a/src/Accordion/Accordion.spec.tsx
+++ b/src/Accordion/Accordion.spec.tsx
@@ -184,29 +184,6 @@ describe('Accordion', () => {
         });
     });
 
-    it('does not expand disabled items on click', () => {
-        const wrapper = mount(
-            <Accordion allowMultipleExpanded={true}>
-                <AccordionItem disabled={true}>
-                    <AccordionItemHeading className="foo">
-                        Foo Title
-                    </AccordionItemHeading>
-                </AccordionItem>
-            </Accordion>,
-        );
-
-        const instance = wrapper.find(Provider).instance() as Provider;
-
-        wrapper
-            .find('.foo')
-            .first()
-            .simulate('click');
-        expect(
-            instance.state.items.filter((item: Item) => item.expanded === true)
-                .length,
-        ).toEqual(0);
-    });
-
     it('pre expanded accordion when allowMultipleExpanded is true', () => {
         const wrapper = mount(
             <Accordion allowMultipleExpanded={true}>

--- a/src/AccordionContainer/AccordionContainer.spec.tsx
+++ b/src/AccordionContainer/AccordionContainer.spec.tsx
@@ -12,7 +12,6 @@ import {
 const DEFAULT_ITEM: Item = {
     uuid: 'foo',
     expanded: false,
-    disabled: false,
 };
 
 describe('Accordion', () => {

--- a/src/AccordionContainer/AccordionContainer.tsx
+++ b/src/AccordionContainer/AccordionContainer.tsx
@@ -10,7 +10,6 @@ export const CONTEXT_KEY = 'react-accessible-accordion@AccordionContainer';
 export type Item = {
     uuid: UUID;
     expanded: boolean;
-    disabled: boolean;
 };
 
 export type ProviderState = {

--- a/src/AccordionItem/AccordionItem.tsx
+++ b/src/AccordionItem/AccordionItem.tsx
@@ -9,19 +9,17 @@ import { UUID } from '../ItemContainer/ItemContainer';
 type AccordionItemProps = React.HTMLAttributes<HTMLDivElement> & {
     uuid: UUID;
     hideBodyClassName?: string;
-    disabled?: boolean;
     expanded?: boolean;
     accordionStore: AccordionContainer;
 };
 
 class AccordionItem extends React.Component<AccordionItemProps> {
     componentDidMount(): void {
-        const { uuid, accordionStore, disabled } = this.props;
+        const { uuid, accordionStore } = this.props;
 
         accordionStore.addItem({
             uuid,
             expanded: this.props.expanded || false,
-            disabled,
         });
     }
 
@@ -43,7 +41,6 @@ class AccordionItem extends React.Component<AccordionItemProps> {
             className,
             hideBodyClassName,
             accordionStore,
-            disabled,
             expanded,
             ...rest
         } = this.props;

--- a/src/AccordionItem/AccordionItem.wrapper.tsx
+++ b/src/AccordionItem/AccordionItem.wrapper.tsx
@@ -11,7 +11,6 @@ import AccordionItem from './AccordionItem';
 
 type AccordionItemWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
     hideBodyClassName?: string;
-    disabled?: boolean;
     expanded?: boolean;
     uuid?: string;
 };
@@ -34,7 +33,6 @@ export default class AccordionItemWrapper extends React.Component<
     static defaultProps: AccordionItemWrapperProps = {
         className: 'accordion__item',
         hideBodyClassName: '',
-        disabled: false,
         expanded: false,
         uuid: undefined,
     };

--- a/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
@@ -11,7 +11,6 @@ describe('AccordionItemHeading', () => {
     const DEFAULT_ITEM: Item = {
         uuid: 0,
         expanded: false,
-        disabled: false,
     };
 
     it('renders null outside the context of an ‘Accordion’', () => {
@@ -97,20 +96,6 @@ describe('AccordionItemHeading', () => {
         expect(isExpanded(wrapper, DEFAULT_ITEM.uuid)).toBeTruthy();
     });
 
-    it('doesn’t toggle state when trying to click but disabled', async () => {
-        const wrapper = mountItem(
-            <AccordionItemHeading>Fake Title</AccordionItemHeading>,
-            {
-                ...DEFAULT_ITEM,
-                disabled: true,
-            },
-        );
-
-        expect(isExpanded(wrapper, DEFAULT_ITEM.uuid)).toBeFalsy();
-        wrapper.find('div').simulate('click');
-        expect(isExpanded(wrapper, DEFAULT_ITEM.uuid)).toBeFalsy();
-    });
-
     it('toggles state when pressing enter', async () => {
         const wrapper = mountItem(
             <AccordionItemHeading>Fake Title</AccordionItemHeading>,
@@ -149,27 +134,5 @@ describe('AccordionItemHeading', () => {
         const div = wrapper.find('div').getDOMNode();
 
         expect(div.getAttribute('lang')).toEqual('en');
-    });
-
-    // edge case to cover branch
-    it('doesn’t toggle state when clicking but disabled & allowMultipleExpanded === false', async () => {
-        const wrapper = mount(
-            <AccordionProvider
-                items={[
-                    {
-                        ...DEFAULT_ITEM,
-                        disabled: true,
-                    },
-                ]}
-            >
-                <ItemProvider uuid={DEFAULT_ITEM.uuid}>
-                    <AccordionItemHeading>Fake Title</AccordionItemHeading>
-                </ItemProvider>
-            </AccordionProvider>,
-        );
-
-        expect(isExpanded(wrapper, DEFAULT_ITEM.uuid)).toBeFalsy();
-        wrapper.find('div').simulate('click');
-        expect(isExpanded(wrapper, DEFAULT_ITEM.uuid)).toBeFalsy();
     });
 });

--- a/src/AccordionItemHeading/AccordionItemHeading.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.tsx
@@ -40,8 +40,7 @@ export default class AccordionItemHeading extends React.Component<
 
         const id = `accordion__heading-${uuid}`;
         const ariaControls = `accordion__panel-${uuid}`;
-        const role = 'button';
-        const titleClassName = classnames(className, {
+        const headingClassName = classnames(className, {
             [hideBodyClassName]: hideBodyClassName && !expanded,
         });
 
@@ -50,7 +49,7 @@ export default class AccordionItemHeading extends React.Component<
                 id={id}
                 aria-expanded={expanded}
                 aria-controls={ariaControls}
-                className={titleClassName}
+                className={headingClassName}
                 onClick={this.handleClick}
                 role="button"
                 tabIndex={0}

--- a/src/AccordionItemHeading/AccordionItemHeading.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.tsx
@@ -6,7 +6,6 @@ type AccordionItemHeadingProps = React.HTMLAttributes<HTMLDivElement> & {
     hideBodyClassName: string;
     expanded: boolean;
     uuid: UUID;
-    disabled: boolean;
     setExpanded(uuid: UUID, expanded: boolean): void;
 };
 
@@ -36,7 +35,6 @@ export default class AccordionItemHeading extends React.Component<
             setExpanded,
             expanded,
             uuid,
-            disabled,
             ...rest
         } = this.props;
 
@@ -46,7 +44,6 @@ export default class AccordionItemHeading extends React.Component<
         const titleClassName = classnames(className, {
             [hideBodyClassName]: hideBodyClassName && !expanded,
         });
-        const onClick = disabled ? undefined : this.handleClick;
 
         return (
             <div
@@ -54,8 +51,8 @@ export default class AccordionItemHeading extends React.Component<
                 aria-expanded={expanded}
                 aria-controls={ariaControls}
                 className={titleClassName}
-                onClick={onClick}
-                role={role}
+                onClick={this.handleClick}
+                role="button"
                 tabIndex={0}
                 onKeyPress={this.handleKeyPress}
                 {...rest}

--- a/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
@@ -12,7 +12,6 @@ describe('AccordionItemPanel', () => {
         const item: Item = {
             uuid: 0,
             expanded: false,
-            disabled: false,
         };
 
         return mount(

--- a/src/AccordionItemPanel/AccordionItemPanel.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.tsx
@@ -6,7 +6,6 @@ type AccordionItemPanelProps = React.HTMLAttributes<HTMLDivElement> & {
     hideBodyClassName: string;
     uuid: UUID;
     expanded: boolean;
-    disabled: boolean;
     allowMultipleExpanded: boolean;
 };
 
@@ -16,7 +15,6 @@ const AccordionItemPanel = (props: AccordionItemPanelProps): JSX.Element => {
         hideBodyClassName,
         uuid,
         expanded,
-        disabled,
         allowMultipleExpanded,
         ...rest
     } = props;


### PR DESCRIPTION
We had the concept of a 'disabled' accordion, as an _undocumented_ feature. Basically, I didn't like that we had mixed mechanisms (internal, and prop-based) for determining whether an AccordionItem is toggle-able, and it was complicating the fix for [this spec compliance issue](https://github.com/springload/react-accessible-accordion/issues/165).