### PR TITLE
Chore/rename hidebodyclassname prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,18 @@ We recommend that you copy them into your own app and modify them to suit your n
     </thead>
     <tbody>
       <tr>
-          <td>accordion</td>
+          <td>allowMultipleExpanded</td>
           <td>Boolean</td>
-          <td>true</td>
-          <td>Open only one item at a time or not</td>
+          <td>false</td>
+          <td>Don't close all the others when expanding an
+                                    AccordionItem</td>
+      </tr>
+      <tr>
+          <td>allowZeroExpanded</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>Close an AccordionItem when it's the only
+                                    one expanded</td>
       </tr>
       <tr>
           <td>onChange</td>
@@ -127,16 +135,22 @@ We recommend that you copy them into your own app and modify them to suit your n
           <td>Expands this item on first render</td>
       </tr>
       <tr>
+          <td>disabled</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>Prevents item from being expanded/collapsed on click</td>
+      </tr>
+      <tr>
           <td>className</td>
           <td>String</td>
           <td>accordion__item</td>
           <td>CSS class(es) applied to the component</td>
       </tr>
       <tr>
-          <td>hideBodyClassName</td>
+          <td>expandedClassName</td>
           <td>String</td>
           <td>null</td>
-          <td>Class name for hidden body state</td>
+          <td>Class name for expanded panel state</td>
       </tr>
       <tr>
           <td>uuid</td>
@@ -168,10 +182,10 @@ We recommend that you copy them into your own app and modify them to suit your n
           <td>CSS class(es) applied to the component</td>
       </tr>
       <tr>
-          <td>hideBodyClassName</td>
+          <td>expandedClassName</td>
           <td>String</td>
           <td>null</td>
-          <td>Class name for hidden body state</td>
+          <td>Class name for expanded panel state</td>
       </tr>
     </tbody>
 </table>
@@ -197,10 +211,10 @@ We recommend that you copy them into your own app and modify them to suit your n
           <td>CSS class(es) applied to the component</td>
       </tr>
       <tr>
-          <td>hideBodyClassName</td>
+          <td>expandedClassName</td>
           <td>String</td>
-          <td>accordion__panel--hidden</td>
-          <td>Class name for hidden body state</td>
+          <td>accordion__panel--expanded</td>
+          <td>Class name for expanded panel state</td>
       </tr>
     </tbody>
 </table>
@@ -226,7 +240,7 @@ This project manages two types of Accordions, with single or multiple items open
 
 #### Single item
 
-> Use this with with props `accordion` set to `true` on `Accordion`.
+> Use this with with props `allowMultipleExpanded` set to `false` on `Accordion`.
 
 For this type of Accordion, you will get the following `role` set up on your elements:
 
@@ -239,7 +253,7 @@ For this type of Accordion, you will get the following `role` set up on your ele
 
 For this type of Accordion, you will get the following `role` set up on your elements:
 
-> Use this with with props `accordion` set to `false` on `Accordion`.
+> Use this with with props `allowMultipleExpanded` set to `true` on `Accordion`.
 
 -   Accordion: no specific role
 -   AccordionItem: no specific role

--- a/README.md
+++ b/README.md
@@ -135,12 +135,6 @@ We recommend that you copy them into your own app and modify them to suit your n
           <td>Expands this item on first render</td>
       </tr>
       <tr>
-          <td>disabled</td>
-          <td>Boolean</td>
-          <td>false</td>
-          <td>Prevents item from being expanded/collapsed on click</td>
-      </tr>
-      <tr>
           <td>className</td>
           <td>String</td>
           <td>accordion__item</td>
@@ -236,29 +230,23 @@ We recommend that you copy them into your own app and modify them to suit your n
 
 ### What this project is doing accessibility-wise?
 
-This project manages two types of Accordions, with single or multiple items open.
+This project manages Accordions with several options available for allowing/not allowing multiple items to be open at once, and allowing/not allowing all items to be closed.
 
-#### Single item
+#### Single item open
 
 > Use this with with props `allowMultipleExpanded` set to `false` on `Accordion`.
 
-For this type of Accordion, you will get the following `role` set up on your elements:
-
--   Accordion: `tablist`
--   AccordionItem: no specific role
--   AccordionItemHeading: `tab`
--   AccordionItemPanel: `tabpanel`
-
-#### Multiple items
-
-For this type of Accordion, you will get the following `role` set up on your elements:
+#### Multiple items open
 
 > Use this with with props `allowMultipleExpanded` set to `true` on `Accordion`.
 
--   Accordion: no specific role
--   AccordionItem: no specific role
--   AccordionItemHeading: `button`
--   AccordionItemPanel: no specific role
+#### One item must remain open
+
+> Use this with with props `allowZeroExpanded` set to `false` on `Accordion`.
+
+#### All items can be closed
+
+> Use this with with props `allowZeroExpanded` set to `true` on `Accordion`.
 
 # Browser support
 

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -212,10 +212,10 @@ const Example = (): JSX.Element => (
                                 <td>CSS class(es) applied to the component</td>
                             </tr>
                             <tr>
-                                <td>hideBody ClassName</td>
+                                <td>expandedClassName</td>
                                 <td>String</td>
-                                <td>accordion__panel--hidden</td>
-                                <td>Class name for hidden body state</td>
+                                <td>accordion__panel--expanded</td>
+                                <td>Class name for expanded panel state</td>
                             </tr>
                         </tbody>
                     </table>
@@ -261,8 +261,8 @@ const Example = (): JSX.Element => (
                                             <td>Boolean</td>
                                             <td>false</td>
                                             <td>
-                                                Open only one item at a time or
-                                                not
+                                                Don't close all the others when
+                                                expanding an AccordionItem
                                             </td>
                                         </tr>
                                         <tr>
@@ -395,11 +395,12 @@ const Example = (): JSX.Element => (
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td>hideBody ClassName</td>
+                                            <td>expandedClassName</td>
                                             <td>String</td>
-                                            <td>accordion__panel--hidden</td>
+                                            <td>accordion__panel--expanded</td>
                                             <td>
-                                                Class name for hidden body state
+                                                Class name for expanded panel
+                                                state
                                             </td>
                                         </tr>
                                     </tbody>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
         },
         {
             "name": "Thibaud Colas"
+        },
+        {
+            "name": "Cate Palmer",
+            "url": "https://github.com/catepalmer"
         }
     ],
     "license": "MIT",

--- a/src/Accordion/Accordion.spec.tsx
+++ b/src/Accordion/Accordion.spec.tsx
@@ -80,18 +80,18 @@ describe('Accordion', () => {
         });
 
         it('works with multiple pre expanded accordion. Extra expands are just ignored.', () => {
-            const hideBodyClassName = 'HIDE';
+            const expandedClassName = 'EXPANDED';
             const wrapper = mount(
                 <Accordion allowMultipleExpanded={false}>
                     <AccordionItem
                         expanded={true}
-                        hideBodyClassName={hideBodyClassName}
+                        expandedClassName={expandedClassName}
                     >
                         Fake Child
                     </AccordionItem>
                     <AccordionItem
                         expanded={true}
-                        hideBodyClassName={hideBodyClassName}
+                        expandedClassName={expandedClassName}
                     >
                         Fake Child
                     </AccordionItem>
@@ -106,7 +106,7 @@ describe('Accordion', () => {
             ).toEqual(1);
             expect(
                 wrapper.findWhere((item: ReactWrapper) =>
-                    item.hasClass(hideBodyClassName),
+                    item.hasClass(expandedClassName),
                 ).length,
             ).toEqual(1);
         });

--- a/src/AccordionItem/AccordionItem.spec.tsx
+++ b/src/AccordionItem/AccordionItem.spec.tsx
@@ -140,21 +140,21 @@ describe('AccordionItem', () => {
         expect(wrapper.find('div').prop('className')).toBe('testCSSClass');
     });
 
-    it('renders with different hideBodyClassName', () => {
-        const wrapper = mount(
-            <AccordionProvider>
-                <AccordionItem
-                    expanded={false}
-                    className="AccordionItem"
-                    hideBodyClassName="AccordionItem--hidden"
-                />
-            </AccordionProvider>,
-        );
+    // it('renders with different expandedClassName', () => {
+    //     const wrapper = mount(
+    //         <AccordionProvider>
+    //             <AccordionItem
+    //                 expanded={true}
+    //                 className="AccordionItem"
+    //                 expandedClassname="AccordionItem--expanded"
+    //             />
+    //         </AccordionProvider>,
+    //     );
 
-        expect(wrapper.find('div').prop('className')).toEqual(
-            'AccordionItem AccordionItem--hidden',
-        );
-    });
+    //     expect(wrapper.find('div').prop('className')).toEqual(
+    //         'AccordionItem AccordionItem--expanded',
+    //     );
+    // });
 
     it('renders correctly with other blocks inside', () => {
         const wrapper = mount(

--- a/src/AccordionItem/AccordionItem.spec.tsx
+++ b/src/AccordionItem/AccordionItem.spec.tsx
@@ -140,21 +140,21 @@ describe('AccordionItem', () => {
         expect(wrapper.find('div').prop('className')).toBe('testCSSClass');
     });
 
-    // it('renders with different expandedClassName', () => {
-    //     const wrapper = mount(
-    //         <AccordionProvider>
-    //             <AccordionItem
-    //                 expanded={true}
-    //                 className="AccordionItem"
-    //                 expandedClassname="AccordionItem--expanded"
-    //             />
-    //         </AccordionProvider>,
-    //     );
+    it('renders with different expandedClassName', () => {
+        const wrapper = mount(
+            <AccordionProvider>
+                <AccordionItem
+                    expanded={true}
+                    className="AccordionItem"
+                    expandedClassName="AccordionItem--expanded"
+                />
+            </AccordionProvider>,
+        );
 
-    //     expect(wrapper.find('div').prop('className')).toEqual(
-    //         'AccordionItem AccordionItem--expanded',
-    //     );
-    // });
+        expect(wrapper.find('div').prop('className')).toEqual(
+            'AccordionItem AccordionItem--expanded',
+        );
+    });
 
     it('renders correctly with other blocks inside', () => {
         const wrapper = mount(

--- a/src/AccordionItem/AccordionItem.tsx
+++ b/src/AccordionItem/AccordionItem.tsx
@@ -8,7 +8,7 @@ import { UUID } from '../ItemContainer/ItemContainer';
 
 type AccordionItemProps = React.HTMLAttributes<HTMLDivElement> & {
     uuid: UUID;
-    hideBodyClassName?: string;
+    expandedClassName?: string;
     expanded?: boolean;
     accordionStore: AccordionContainer;
 };
@@ -39,7 +39,7 @@ class AccordionItem extends React.Component<AccordionItemProps> {
         const {
             uuid,
             className,
-            hideBodyClassName,
+            expandedClassName,
             accordionStore,
             expanded,
             ...rest
@@ -57,8 +57,8 @@ class AccordionItem extends React.Component<AccordionItemProps> {
         return (
             <div
                 className={classnames(className, {
-                    [String(hideBodyClassName)]:
-                        !currentItem.expanded && hideBodyClassName,
+                    [String(expandedClassName)]:
+                        currentItem.expanded && expandedClassName,
                 })}
                 {...rest}
             />

--- a/src/AccordionItem/AccordionItem.wrapper.tsx
+++ b/src/AccordionItem/AccordionItem.wrapper.tsx
@@ -10,7 +10,7 @@ import { Provider as ItemProvider } from '../ItemContainer/ItemContainer';
 import AccordionItem from './AccordionItem';
 
 type AccordionItemWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
-    hideBodyClassName?: string;
+    expandedClassName?: string;
     expanded?: boolean;
     uuid?: string;
 };
@@ -32,7 +32,7 @@ export default class AccordionItemWrapper extends React.Component<
 
     static defaultProps: AccordionItemWrapperProps = {
         className: 'accordion__item',
-        hideBodyClassName: '',
+        expandedClassName: '',
         expanded: false,
         uuid: undefined,
     };

--- a/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
+++ b/src/AccordionItem/__snapshots__/AccordionItem.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`AccordionItem renders correctly with allowMultipleExpanded false 1`] = 
   <div
     aria-hidden={null}
     aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
+    className="accordion__panel"
     id="accordion__panel-0"
     role="region"
   >
@@ -55,7 +55,7 @@ exports[`AccordionItem renders correctly with allowMultipleExpanded true 1`] = `
   <div
     aria-hidden={true}
     aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
+    className="accordion__panel"
     id="accordion__panel-0"
     role={null}
   >
@@ -88,7 +88,7 @@ exports[`AccordionItem renders correctly with allowZeroExpanded false 1`] = `
   <div
     aria-hidden={null}
     aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
+    className="accordion__panel"
     id="accordion__panel-0"
     role="region"
   >
@@ -121,7 +121,7 @@ exports[`AccordionItem renders correctly with allowZeroExpanded true 1`] = `
   <div
     aria-hidden={null}
     aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
+    className="accordion__panel"
     id="accordion__panel-0"
     role="region"
   >
@@ -157,7 +157,7 @@ exports[`AccordionItem renders correctly with other blocks inside 1`] = `
   <div
     aria-hidden={null}
     aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
+    className="accordion__panel"
     id="accordion__panel-0"
     role="region"
   >
@@ -190,7 +190,7 @@ exports[`AccordionItem renders correctly with other blocks inside 2 1`] = `
   <div
     aria-hidden={null}
     aria-labelledby="accordion__heading-0"
-    className="accordion__panel accordion__panel--hidden"
+    className="accordion__panel"
     id="accordion__panel-0"
     role="region"
   >

--- a/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
@@ -70,20 +70,12 @@ describe('AccordionItemHeading', () => {
         expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
-    it('renders with different hideBodyClassName', () => {
-        const hideBodyClassName = 'hideBodyClassName';
+    it('renders with different expandedClassName', () => {
+        const expandedClassName = 'expandedClassName';
         const wrapper = mountItem(
-            <AccordionItemHeading hideBodyClassName={hideBodyClassName} />,
+            <AccordionItemHeading expandedClassName={expandedClassName} />,
         );
-        expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(true);
-    });
-
-    it("doesn't present hideBodyClassName when collapsed", () => {
-        const hideBodyClassName = 'hideBodyClassName';
-        const wrapper = mountItem(
-            <AccordionItemHeading hideBodyClassName={hideBodyClassName} />,
-        );
-        expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(true);
+        expect(wrapper.find('div').hasClass(expandedClassName)).toEqual(true);
     });
 
     it('toggles state when clicked', async () => {

--- a/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.spec.tsx
@@ -70,10 +70,17 @@ describe('AccordionItemHeading', () => {
         expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
-    it('renders with different expandedClassName', () => {
+    it('renders with different expandedClassName when item is expanded', () => {
         const expandedClassName = 'expandedClassName';
-        const wrapper = mountItem(
-            <AccordionItemHeading expandedClassName={expandedClassName} />,
+
+        const wrapper = mount(
+            <AccordionProvider items={[{ uuid: 0, expanded: true }]}>
+                <ItemProvider uuid={0}>
+                    <AccordionItemHeading
+                        expandedClassName={expandedClassName}
+                    />
+                </ItemProvider>
+            </AccordionProvider>,
         );
         expect(wrapper.find('div').hasClass(expandedClassName)).toEqual(true);
     });

--- a/src/AccordionItemHeading/AccordionItemHeading.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { UUID } from '../ItemContainer/ItemContainer';
 
 type AccordionItemHeadingProps = React.HTMLAttributes<HTMLDivElement> & {
-    hideBodyClassName: string;
+    expandedClassName: string;
     expanded: boolean;
     uuid: UUID;
     disabled: boolean;
@@ -32,7 +32,7 @@ export default class AccordionItemHeading extends React.Component<
     render(): JSX.Element {
         const {
             className,
-            hideBodyClassName,
+            expandedClassName,
             setExpanded,
             expanded,
             uuid,
@@ -42,8 +42,9 @@ export default class AccordionItemHeading extends React.Component<
 
         const id = `accordion__heading-${uuid}`;
         const ariaControls = `accordion__panel-${uuid}`;
+
         const headingClassName = classnames(className, {
-            [hideBodyClassName]: hideBodyClassName && !expanded,
+            [expandedClassName]: expandedClassName && expanded,
         });
 
         return (

--- a/src/AccordionItemHeading/AccordionItemHeading.wrapper.tsx
+++ b/src/AccordionItemHeading/AccordionItemHeading.wrapper.tsx
@@ -12,7 +12,7 @@ import {
 import { default as AccordionItemHeading } from './AccordionItemHeading';
 
 type AccordionItemHeadingWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
-    hideBodyClassName: string;
+    expandedClassName: string;
 };
 
 type AccordionItemHeadingWrapperState = {};
@@ -32,7 +32,7 @@ export default class AccordionItemHeadingWrapper extends React.Component<
 
     static defaultProps: AccordionItemHeadingWrapperProps = {
         className: 'accordion__heading',
-        hideBodyClassName: '',
+        expandedClassName: '',
     };
 
     render(): JSX.Element {

--- a/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
@@ -11,7 +11,7 @@ describe('AccordionItemPanel', () => {
     function mountItem(children: React.ReactNode): ReactWrapper {
         const item: Item = {
             uuid: 0,
-            expanded: false,
+            expanded: true,
         };
 
         return mount(
@@ -36,7 +36,7 @@ describe('AccordionItemPanel', () => {
         expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
-    it('renders correctly with different expandedClassName', () => {
+    it('renders correctly with different expandedClassName when item is expanded', () => {
         const expandedClassName = 'expandedClassName';
         const wrapper = mountItem(
             <AccordionItemPanel expandedClassName={expandedClassName} />,

--- a/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.spec.tsx
@@ -36,12 +36,12 @@ describe('AccordionItemPanel', () => {
         expect(wrapper.find('div').hasClass(className)).toEqual(true);
     });
 
-    it('renders correctly with different hideBodyClassName', () => {
-        const hideBodyClassName = 'hideBodyClassName';
+    it('renders correctly with different expandedClassName', () => {
+        const expandedClassName = 'expandedClassName';
         const wrapper = mountItem(
-            <AccordionItemPanel hideBodyClassName={hideBodyClassName} />,
+            <AccordionItemPanel expandedClassName={expandedClassName} />,
         );
-        expect(wrapper.find('div').hasClass(hideBodyClassName)).toEqual(true);
+        expect(wrapper.find('div').hasClass(expandedClassName)).toEqual(true);
     });
 
     it('respects arbitrary user-defined props', () => {

--- a/src/AccordionItemPanel/AccordionItemPanel.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { UUID } from '../ItemContainer/ItemContainer';
 
 type AccordionItemPanelProps = React.HTMLAttributes<HTMLDivElement> & {
-    hideBodyClassName: string;
+    expandedClassName: string;
     uuid: UUID;
     expanded: boolean;
     allowMultipleExpanded: boolean;
@@ -12,7 +12,7 @@ type AccordionItemPanelProps = React.HTMLAttributes<HTMLDivElement> & {
 const AccordionItemPanel = (props: AccordionItemPanelProps): JSX.Element => {
     const {
         className,
-        hideBodyClassName,
+        expandedClassName,
         uuid,
         expanded,
         allowMultipleExpanded,
@@ -26,7 +26,7 @@ const AccordionItemPanel = (props: AccordionItemPanelProps): JSX.Element => {
         <div
             id={`accordion__panel-${uuid}`}
             className={classnames(className, {
-                [hideBodyClassName]: !expanded,
+                [expandedClassName]: expanded,
             })}
             aria-hidden={hideAriaAttribute}
             aria-labelledby={`accordion__heading-${uuid}`}

--- a/src/AccordionItemPanel/AccordionItemPanel.wrapper.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.wrapper.tsx
@@ -13,7 +13,7 @@ import {
 import AccordionItemPanel from './AccordionItemPanel';
 
 type AccordionItemPanelWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
-    hideBodyClassName: string;
+    expandedClassName: string;
 };
 
 type AccordionItemPanelWrapperState = {};
@@ -35,7 +35,7 @@ export default class AccordionItemPanelWrapper extends React.Component<
 
     static defaultProps: AccordionItemPanelWrapperProps = {
         className: 'accordion__panel',
-        hideBodyClassName: 'accordion__panel--hidden',
+        expandedClassName: 'accordion__panel--expanded',
     };
 
     render(): JSX.Element {

--- a/src/AccordionItemPanel/__snapshots__/AccordionItemPanel.spec.tsx.snap
+++ b/src/AccordionItemPanel/__snapshots__/AccordionItemPanel.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`AccordionItemPanel renders correctly with min params 1`] = `
 <div
   aria-hidden={null}
   aria-labelledby="accordion__heading-0"
-  className="accordion__panel accordion__panel--hidden"
+  className="accordion__panel"
   id="accordion__panel-0"
   role="region"
 >

--- a/src/AccordionItemPanel/__snapshots__/AccordionItemPanel.spec.tsx.snap
+++ b/src/AccordionItemPanel/__snapshots__/AccordionItemPanel.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`AccordionItemPanel renders correctly with min params 1`] = `
 <div
   aria-hidden={null}
   aria-labelledby="accordion__heading-0"
-  className="accordion__panel"
+  className="accordion__panel accordion__panel--expanded"
   id="accordion__panel-0"
   role="region"
 >

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -39,14 +39,14 @@
 }
 
 .accordion__panel {
-    padding: 20px;
-    display: block;
+    display: none;
+    opacity: 0;
     animation: fadein 0.35s ease-in;
 }
 
-.accordion__panel--hidden {
-    display: none;
-    opacity: 0;
+.accordion__panel--expanded {
+    padding: 20px;
+    display: block;
     animation: fadein 0.35s ease-in;
 }
 

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -39,13 +39,13 @@
 }
 
 .accordion__panel {
+    padding: 20px;
     display: none;
     opacity: 0;
     animation: fadein 0.35s ease-in;
 }
 
 .accordion__panel--expanded {
-    padding: 20px;
     display: block;
     animation: fadein 0.35s ease-in;
 }

--- a/src/css/minimal-example.css
+++ b/src/css/minimal-example.css
@@ -1,7 +1,7 @@
 .accordion__panel {
-    display: block;
+    display: none;
 }
 
-.accordion__panel--hidden {
-    display: none;
+.accordion__panel--expanded {
+    display: block;
 }


### PR DESCRIPTION
Have renamed the `hideBodyClassName` prop to `expandedClassName`, as proposed in issue #164 (with the appropriate conditionals changed so that the class `accordion__panel--expanded` is passed to accordion item panels that are expanded rather than collapsed). I also noticed that the read me was out of date and hadn't been updated to reflect the recent changes to the `next` branch, so I've tried to update that too.