### PR TITLE
Render-prop component

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,35 @@ We recommend that you copy them into your own app and modify them to suit your n
     </tbody>
 </table>
 
+### AccordionItemState
+
+#### props:
+
+<table class="table table-bordered table-striped">
+    <thead>
+    <tr>
+        <th style="width: 100px;">name</th>
+        <th style="width: 50px;">type</th>
+        <th>default</th>
+        <th>description</th>
+    </tr>
+    </thead>
+    <tbody>
+      <tr>
+          <td>expanded</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>Expands this item on first render</td>
+      </tr>
+      <tr>
+          <td>render</td>
+          <td>Function</td>
+          <td>returns null</td>
+          <td>Takes expanded state as argument for conditional rendering</td>
+      </tr>
+    </tbody>
+</table>
+
 ### resetNextUuid
 
 <table class="table table-bordered table-striped">

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ We recommend that you copy them into your own app and modify them to suit your n
       <tr>
           <td>render</td>
           <td>Function</td>
-          <td>returns null</td>
+          <td>null</td>
           <td>Takes expanded state as argument for conditional rendering</td>
       </tr>
     </tbody>

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ We recommend that you copy them into your own app and modify them to suit your n
           <td>Expands this item on first render</td>
       </tr>
       <tr>
-          <td>render</td>
+          <td>children</td>
           <td>Function</td>
           <td>null</td>
           <td>Takes expanded state as argument for conditional rendering</td>

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -8,6 +8,7 @@ import {
     AccordionItem,
     AccordionItemHeading,
     AccordionItemPanel,
+    AccordionItemState,
 } from '../../src';
 
 // tslint:disable-next-line no-import-side-effect
@@ -15,6 +16,10 @@ import './main.css';
 
 // tslint:disable-next-line no-import-side-effect ordered-imports
 import '../../src/css/fancy-example.css';
+
+const renderFn = (expanded: boolean): JSX.Element => {
+    return expanded ? <>This item is expanded</> : <>This item is collapsed</>;
+};
 
 // tslint:disable-next-line max-func-body-length
 const Example = (): JSX.Element => (
@@ -649,6 +654,52 @@ const Example = (): JSX.Element => (
                     <p>
                         If you open/close this item you should see
                         `uniqueItem-2` printed in the console.
+                    </p>
+                </AccordionItemPanel>
+            </AccordionItem>
+        </Accordion>
+
+        <h2 className="u-margin-top">Conditional display</h2>
+
+        <Accordion>
+            <AccordionItem>
+                <AccordionItemHeading>
+                    <div>
+                        <h3 className="u-position-relative">
+                            Display a different icon when expanded
+                            <div
+                                className="accordion__arrow"
+                                role="presentation"
+                            />
+                        </h3>
+                        <AccordionItemState render={renderFn} />
+                    </div>
+                </AccordionItemHeading>
+                <AccordionItemPanel>
+                    <p>
+                        When you open/close this item, you should see the icon
+                        next to the heading change.
+                    </p>
+                </AccordionItemPanel>
+            </AccordionItem>
+            <AccordionItem>
+                <AccordionItemHeading>
+                    <div>
+                        <h3 className="u-position-relative">
+                            How to?
+                            <div
+                                className="accordion__arrow"
+                                role="presentation"
+                            />
+                        </h3>
+                        <AccordionItemState render={renderFn} />
+                    </div>
+                </AccordionItemHeading>
+                <AccordionItemPanel>
+                    <p>
+                        Use the AccordionItemState component inside an Accordion
+                        item and pass it a render prop function that takes the
+                        item's expanded/collapsed state.
                     </p>
                 </AccordionItemPanel>
             </AccordionItem>

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -254,7 +254,7 @@ const Example = (): JSX.Element => (
                             <tr>
                                 <td>render</td>
                                 <td>Function</td>
-                                <td>returns null</td>
+                                <td>null</td>
                                 <td>
                                     Takes expanded state as argument for
                                     conditional rendering
@@ -444,6 +444,49 @@ const Example = (): JSX.Element => (
                                             <td>
                                                 Class name for expanded panel
                                                 state
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </AccordionItemPanel>
+                        </AccordionItem>
+                        <AccordionItem>
+                            <AccordionItemHeading>
+                                <h3 className="u-position-relative">
+                                    AccordionItemState
+                                    <div
+                                        className="accordion__arrow"
+                                        role="presentation"
+                                    />
+                                </h3>
+                            </AccordionItemHeading>
+                            <AccordionItemPanel>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th>name</th>
+                                            <th>type</th>
+                                            <th>default</th>
+                                            <th>description</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>expanded</td>
+                                            <td>Boolean</td>
+                                            <td>false</td>
+                                            <td>
+                                                Expands this item on first
+                                                render
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>render</td>
+                                            <td>Function</td>
+                                            <td>null</td>
+                                            <td>
+                                                Takes expanded state as argument
+                                                for conditional rendering
                                             </td>
                                         </tr>
                                     </tbody>

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -252,7 +252,7 @@ const Example = (): JSX.Element => (
                                 <td>Expands this item on first render</td>
                             </tr>
                             <tr>
-                                <td>render</td>
+                                <td>children</td>
                                 <td>Function</td>
                                 <td>null</td>
                                 <td>
@@ -481,7 +481,7 @@ const Example = (): JSX.Element => (
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td>render</td>
+                                            <td>children</td>
                                             <td>Function</td>
                                             <td>null</td>
                                             <td>
@@ -753,7 +753,7 @@ const Example = (): JSX.Element => (
                                 role="presentation"
                             />
                         </h3>
-                        <AccordionItemState render={renderFn} />
+                        <AccordionItemState children={renderFn} />
                     </div>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
@@ -773,7 +773,7 @@ const Example = (): JSX.Element => (
                                 role="presentation"
                             />
                         </h3>
-                        <AccordionItemState render={renderFn} />
+                        <AccordionItemState children={renderFn} />
                     </div>
                 </AccordionItemHeading>
                 <AccordionItemPanel>

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -8,6 +8,7 @@ import {
     AccordionItem,
     AccordionItemHeading,
     AccordionItemPanel,
+    AccordionItemState,
 } from '../../src';
 
 // tslint:disable-next-line no-import-side-effect

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -8,7 +8,6 @@ import {
     AccordionItem,
     AccordionItemHeading,
     AccordionItemPanel,
-    AccordionItemState,
 } from '../../src';
 
 // tslint:disable-next-line no-import-side-effect

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -70,6 +70,7 @@ const Example = (): JSX.Element => (
                         <li>AccordionItem</li>
                         <li>AccordionItemHeading</li>
                         <li>AccordionItemPanel</li>
+                        <li>AccordionItemState</li>
                     </ul>
                 </AccordionItemPanel>
             </AccordionItem>
@@ -221,6 +222,43 @@ const Example = (): JSX.Element => (
                                 <td>String</td>
                                 <td>accordion__panel--expanded</td>
                                 <td>Class name for expanded panel state</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </AccordionItemPanel>
+            </AccordionItem>
+            <AccordionItem>
+                <AccordionItemHeading>
+                    <h3 className="u-position-relative">
+                        AccordionItemState
+                        <div className="accordion__arrow" role="presentation" />
+                    </h3>
+                </AccordionItemHeading>
+                <AccordionItemPanel>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>name</th>
+                                <th>type</th>
+                                <th>default</th>
+                                <th>description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>expanded</td>
+                                <td>Boolean</td>
+                                <td>false</td>
+                                <td>Expands this item on first render</td>
+                            </tr>
+                            <tr>
+                                <td>render</td>
+                                <td>Function</td>
+                                <td>returns null</td>
+                                <td>
+                                    Takes expanded state as argument for
+                                    conditional rendering
+                                </td>
                             </tr>
                         </tbody>
                     </table>
@@ -666,7 +704,7 @@ const Example = (): JSX.Element => (
                 <AccordionItemHeading>
                     <div>
                         <h3 className="u-position-relative">
-                            Display a different icon when expanded
+                            Render something different when expanded
                             <div
                                 className="accordion__arrow"
                                 role="presentation"
@@ -677,8 +715,8 @@ const Example = (): JSX.Element => (
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>
-                        When you open/close this item, you should see the icon
-                        next to the heading change.
+                        When you open/close this item, you should see the text
+                        under the heading change.
                     </p>
                 </AccordionItemPanel>
             </AccordionItem>
@@ -697,9 +735,12 @@ const Example = (): JSX.Element => (
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>
-                        Use the AccordionItemState component inside an Accordion
-                        item and pass it a render prop function that takes the
-                        item's expanded/collapsed state.
+                        Pass the AccordionItemState component a render prop
+                        function.
+                    </p>
+                    <p>
+                        This should take the item's expanded state as an
+                        argument.
                     </p>
                 </AccordionItemPanel>
             </AccordionItem>

--- a/src/AccordionItemPanel/AccordionItemPanel.tsx
+++ b/src/AccordionItemPanel/AccordionItemPanel.tsx
@@ -35,5 +35,4 @@ const AccordionItemPanel = (props: AccordionItemPanelProps): JSX.Element => {
         />
     );
 };
-
 export default AccordionItemPanel;

--- a/src/AccordionItemState/AccordionItemState.spec.tsx
+++ b/src/AccordionItemState/AccordionItemState.spec.tsx
@@ -22,20 +22,14 @@ describe('AccordionItemState', () => {
     }
 
     it('renders correctly with min params', () => {
-        const wrapper = mountItem(
-            <AccordionItemState>
-                <div>Fake body</div>
-            </AccordionItemState>,
-        );
+        const wrapper = mountItem(<AccordionItemState />);
         expect(wrapper).toMatchSnapshot();
     });
 
     it('does not render if no accordionStore found in context', () => {
         const wrapper = mount(
             <ItemProvider uuid="foo">
-                <AccordionItemState>
-                    <div data-enzyme={true}>Hello World</div>
-                </AccordionItemState>
+                <AccordionItemState />
             </ItemProvider>,
         );
 
@@ -44,13 +38,54 @@ describe('AccordionItemState', () => {
 
     it('does not render if no itemStore found in context', () => {
         const wrapper = mount(
-            <AccordionProvider allowMultipleExpanded={false} items={[]}>
-                <AccordionItemState>
-                    <div data-enzyme={true}>Hello World</div>
-                </AccordionItemState>
+            <AccordionProvider items={[]}>
+                <AccordionItemState />
             </AccordionProvider>,
         );
 
         expect(wrapper.find('div[data-enzyme]').length).toEqual(0);
+    });
+
+    it('renders correctly with different render prop', () => {
+        const renderProp = (expanded: boolean): React.ReactNode =>
+            expanded ? (
+                <div className="expanded" />
+            ) : (
+                <div className="collapsed" />
+            );
+
+        const wrapper = mountItem(<AccordionItemState render={renderProp} />);
+
+        expect(wrapper.find('div').hasClass('expanded')).toEqual(true);
+        expect(wrapper.find('div').hasClass('collapsed')).toEqual(false);
+    });
+
+    it('renders correctly with different render prop and expanded set to false', () => {
+        function mountExpandedFalse(children: React.ReactNode): ReactWrapper {
+            const item: Item = {
+                uuid: 0,
+                expanded: false,
+            };
+
+            return mount(
+                <AccordionProvider items={[item]}>
+                    <ItemProvider uuid={item.uuid}>{children}</ItemProvider>
+                </AccordionProvider>,
+            );
+        }
+
+        const renderProp = (expanded: boolean): React.ReactNode =>
+            expanded ? (
+                <div className="expanded" />
+            ) : (
+                <div className="collapsed" />
+            );
+
+        const wrapper = mountExpandedFalse(
+            <AccordionItemState render={renderProp} />,
+        );
+
+        expect(wrapper.find('div').hasClass('expanded')).toEqual(false);
+        expect(wrapper.find('div').hasClass('collapsed')).toEqual(true);
     });
 });

--- a/src/AccordionItemState/AccordionItemState.spec.tsx
+++ b/src/AccordionItemState/AccordionItemState.spec.tsx
@@ -46,7 +46,7 @@ describe('AccordionItemState', () => {
         expect(wrapper.find('div[data-enzyme]').length).toEqual(0);
     });
 
-    it('renders correctly with different render prop', () => {
+    it('renders correctly with different children prop', () => {
         const renderProp = (expanded: boolean): React.ReactNode =>
             expanded ? (
                 <div className="expanded" />
@@ -54,13 +54,13 @@ describe('AccordionItemState', () => {
                 <div className="collapsed" />
             );
 
-        const wrapper = mountItem(<AccordionItemState render={renderProp} />);
+        const wrapper = mountItem(<AccordionItemState children={renderProp} />);
 
         expect(wrapper.find('div').hasClass('expanded')).toEqual(true);
         expect(wrapper.find('div').hasClass('collapsed')).toEqual(false);
     });
 
-    it('renders correctly with different render prop and expanded set to false', () => {
+    it('renders correctly with different children prop and expanded set to false', () => {
         function mountExpandedFalse(children: React.ReactNode): ReactWrapper {
             const item: Item = {
                 uuid: 0,
@@ -82,7 +82,7 @@ describe('AccordionItemState', () => {
             );
 
         const wrapper = mountExpandedFalse(
-            <AccordionItemState render={renderProp} />,
+            <AccordionItemState children={renderProp} />,
         );
 
         expect(wrapper.find('div').hasClass('expanded')).toEqual(false);

--- a/src/AccordionItemState/AccordionItemState.spec.tsx
+++ b/src/AccordionItemState/AccordionItemState.spec.tsx
@@ -1,0 +1,56 @@
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+import {
+    Item,
+    Provider as AccordionProvider,
+} from '../AccordionContainer/AccordionContainer';
+import { Provider as ItemProvider } from '../ItemContainer/ItemContainer';
+import { default as AccordionItemState } from './AccordionItemState.wrapper';
+
+describe('AccordionItemState', () => {
+    function mountItem(children: React.ReactNode): ReactWrapper {
+        const item: Item = {
+            uuid: 0,
+            expanded: true,
+        };
+
+        return mount(
+            <AccordionProvider items={[item]}>
+                <ItemProvider uuid={item.uuid}>{children}</ItemProvider>
+            </AccordionProvider>,
+        );
+    }
+
+    it('renders correctly with min params', () => {
+        const wrapper = mountItem(
+            <AccordionItemState>
+                <div>Fake body</div>
+            </AccordionItemState>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('does not render if no accordionStore found in context', () => {
+        const wrapper = mount(
+            <ItemProvider uuid="foo">
+                <AccordionItemState>
+                    <div data-enzyme={true}>Hello World</div>
+                </AccordionItemState>
+            </ItemProvider>,
+        );
+
+        expect(wrapper.find('div[data-enzyme]').length).toEqual(0);
+    });
+
+    it('does not render if no itemStore found in context', () => {
+        const wrapper = mount(
+            <AccordionProvider allowMultipleExpanded={false} items={[]}>
+                <AccordionItemState>
+                    <div data-enzyme={true}>Hello World</div>
+                </AccordionItemState>
+            </AccordionProvider>,
+        );
+
+        expect(wrapper.find('div[data-enzyme]').length).toEqual(0);
+    });
+});

--- a/src/AccordionItemState/AccordionItemState.tsx
+++ b/src/AccordionItemState/AccordionItemState.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 
 type AccordionItemStateProps = React.HTMLAttributes<HTMLDivElement> & {
     expanded: boolean;
+    render(expanded: boolean): React.ReactNode;
 };
 
 const AccordionItemState = (props: AccordionItemStateProps): JSX.Element => {
-    return <></>;
+    return <>{props.render(props.expanded)}</>;
 };
 export default AccordionItemState;

--- a/src/AccordionItemState/AccordionItemState.tsx
+++ b/src/AccordionItemState/AccordionItemState.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 type AccordionItemStateProps = React.HTMLAttributes<HTMLDivElement> & {
     expanded: boolean;
-    render(expanded: boolean): React.ReactNode;
+    children(expanded: boolean): React.ReactNode;
 };
 
 const AccordionItemState = (props: AccordionItemStateProps): JSX.Element => {
-    return <>{props.render(props.expanded)}</>;
+    return <>{props.children(props.expanded)}</>;
 };
 export default AccordionItemState;

--- a/src/AccordionItemState/AccordionItemState.tsx
+++ b/src/AccordionItemState/AccordionItemState.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+type AccordionItemStateProps = React.HTMLAttributes<HTMLDivElement> & {
+    expanded: boolean;
+};
+
+const AccordionItemState = (props: AccordionItemStateProps): JSX.Element => {
+    return <></>;
+};
+export default AccordionItemState;

--- a/src/AccordionItemState/AccordionItemState.wrapper.tsx
+++ b/src/AccordionItemState/AccordionItemState.wrapper.tsx
@@ -15,7 +15,7 @@ import AccordionItemState from './AccordionItemState';
 
 type AccordionItemStateWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
     expanded?: boolean;
-    render(expanded: boolean): React.ReactNode;
+    children(expanded: boolean): React.ReactNode;
 };
 
 type AccordionItemStateWrapperContext = {
@@ -33,7 +33,7 @@ export default class AccordionItemStateWrapper extends React.Component<
     };
 
     static defaultProps: AccordionItemStateWrapperProps = {
-        render: (expanded: boolean): React.ReactNode => null,
+        children: (expanded: boolean): React.ReactNode => null,
     };
 
     render(): JSX.Element {
@@ -64,10 +64,10 @@ export default class AccordionItemStateWrapper extends React.Component<
         const item = items.filter(
             (stateItem: Item) => stateItem.uuid === uuid,
         )[0];
-        const { render } = this.props;
+        const { children } = this.props;
 
         return item ? (
-            <AccordionItemState expanded={item.expanded} render={render} />
+            <AccordionItemState expanded={item.expanded} children={children} />
         ) : null;
     }
 }

--- a/src/AccordionItemState/AccordionItemState.wrapper.tsx
+++ b/src/AccordionItemState/AccordionItemState.wrapper.tsx
@@ -15,7 +15,7 @@ import AccordionItemState from './AccordionItemState';
 
 type AccordionItemStateWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
     expanded?: boolean;
-    render?(): React.ReactFragment;
+    render(expanded: boolean): React.ReactNode;
 };
 
 type AccordionItemStateWrapperContext = {
@@ -30,6 +30,10 @@ export default class AccordionItemStateWrapper extends React.Component<
     static contextTypes: AccordionItemStateWrapperContext = {
         [ACCORDION_CONTEXT_KEY]: propTypes.wildcard,
         [ITEM_CONTEXT_KEY]: propTypes.wildcard,
+    };
+
+    static defaultProps: AccordionItemStateWrapperProps = {
+        render: (expanded: boolean): React.ReactNode => null,
     };
 
     render(): JSX.Element {
@@ -60,7 +64,10 @@ export default class AccordionItemStateWrapper extends React.Component<
         const item = items.filter(
             (stateItem: Item) => stateItem.uuid === uuid,
         )[0];
+        const { render } = this.props;
 
-        return item ? <AccordionItemState expanded={item.expanded} /> : null;
+        return item ? (
+            <AccordionItemState expanded={item.expanded} render={render} />
+        ) : null;
     }
 }

--- a/src/AccordionItemState/AccordionItemState.wrapper.tsx
+++ b/src/AccordionItemState/AccordionItemState.wrapper.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import * as propTypes from '../helpers/propTypes';
+
+import {
+    CONTEXT_KEY as ACCORDION_CONTEXT_KEY,
+    getAccordionStore,
+    Item,
+} from '../AccordionContainer/AccordionContainer';
+import {
+    CONTEXT_KEY as ITEM_CONTEXT_KEY,
+    getItemStore,
+} from '../ItemContainer/ItemContainer';
+
+import AccordionItemState from './AccordionItemState';
+
+type AccordionItemStateWrapperProps = React.HTMLAttributes<HTMLDivElement> & {
+    expanded?: boolean;
+    render?(): React.ReactFragment;
+};
+
+type AccordionItemStateWrapperContext = {
+    [ACCORDION_CONTEXT_KEY](): null;
+    [ITEM_CONTEXT_KEY](): null;
+};
+
+export default class AccordionItemStateWrapper extends React.Component<
+    AccordionItemStateWrapperProps,
+    AccordionItemStateWrapperContext
+> {
+    static contextTypes: AccordionItemStateWrapperContext = {
+        [ACCORDION_CONTEXT_KEY]: propTypes.wildcard,
+        [ITEM_CONTEXT_KEY]: propTypes.wildcard,
+    };
+
+    render(): JSX.Element {
+        const accordionStore = getAccordionStore(this.context);
+
+        if (!accordionStore) {
+            // tslint:disable-next-line:no-console
+            console.error(
+                'AccordionItemState component cannot render because it has not been nested inside an Accordion component.',
+            );
+
+            return null;
+        }
+
+        const itemStore = getItemStore(this.context);
+
+        if (!itemStore) {
+            // tslint:disable-next-line:no-console
+            console.error(
+                'AccordionItemState component cannot render because it has not been nested inside an AccordionItem component.',
+            );
+
+            return null;
+        }
+
+        const { uuid } = itemStore;
+        const { items } = accordionStore;
+        const item = items.filter(
+            (stateItem: Item) => stateItem.uuid === uuid,
+        )[0];
+
+        return item ? <AccordionItemState expanded={item.expanded} /> : null;
+    }
+}

--- a/src/AccordionItemState/__snapshots__/AccordionItemState.spec.tsx.snap
+++ b/src/AccordionItemState/__snapshots__/AccordionItemState.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccordionItemState renders correctly with min params 1`] = `""`;

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -46,7 +46,6 @@
 
 .accordion__panel--expanded {
     display: block;
-    animation: fadein 0.35s ease-in;
 }
 
 .accordion__heading > *:last-child,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import AccordionWrapper from './Accordion/Accordion.wrapper';
 import AccordionItemWrapper from './AccordionItem/AccordionItem.wrapper';
 import AccordionItemHeadingWrapper from './AccordionItemHeading/AccordionItemHeading.wrapper';
 import AccordionItemPanelWrapper from './AccordionItemPanel/AccordionItemPanel.wrapper';
+import AccordionItemStateWrapper from './AccordionItemState/AccordionItemState.wrapper';
 import { resetNextUuid } from './helpers/uuid';
 
 export {
@@ -9,5 +10,6 @@ export {
     AccordionItemWrapper as AccordionItem,
     AccordionItemHeadingWrapper as AccordionItemHeading,
     AccordionItemPanelWrapper as AccordionItemPanel,
+    AccordionItemStateWrapper as AccordionItemState,
     resetNextUuid,
 };


### PR DESCRIPTION
Have added an `AccordionItemState` render-prop component that exposes the Accordion item's `expanded` state from context and also takes a function as its `render` prop, as proposed in issue #143.

People seemed to want to go with @ryami333's first proposal

> 1. We add an AccordionItemState render-prop component, which gives the state of the AccordionItem in context.

rather than the second,

> 2. We update the AccordionItem component API to be a render-prop component itself, which gives its own state as a render-prop argument.

so that was what I went with. I've also added a description of the `AccordionItemState` component to the `README.md` and the `demo/src/index.tsx`.