### PR TITLE
Enable down-arrow and up-arrow tests

### DIFF
--- a/integration/wai-aria.spec.js
+++ b/integration/wai-aria.spec.js
@@ -112,7 +112,7 @@ describe('WAI ARIA Spec', () => {
         });
 
         describe('Down Arrow (Optional)', () => {
-            xit('If focus is on an accordion header, moves focus to the next accordion header.', async () => {
+            it('If focus is on an accordion header, moves focus to the next accordion header.', async () => {
                 const [
                     firstHeadingHandle,
                     secondHeadingHandle,
@@ -132,7 +132,7 @@ describe('WAI ARIA Spec', () => {
         });
 
         describe('Up Arrow (Optional)', () => {
-            xit('If focus is on an accordion header, moves focus to the previous accordion header.', async () => {
+            it('If focus is on an accordion header, moves focus to the previous accordion header.', async () => {
                 const [
                     firstHeadingHandle,
                     secondHeadingHandle,


### PR DESCRIPTION
Forgot to enable some integration tests for keyboard functionality.