### PR TITLE
Chore/styles refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,9 @@ export default function Example() {
 ### Styles
 
 We strongly encourage you to write your own styles for your accordions, but
-we've published these two starter stylesheets to help you get up and running:
+we've published the styles used on our demo page to help you get up and running:
 
 ```js
-// 'Minimal' theme - hide/show the AccordionBody component:
-import 'react-accessible-accordion/dist/minimal-example.css';
-
-// 'Fancy' theme - boilerplate styles for all components, as seen on our demo:
 import 'react-accessible-accordion/dist/fancy-example.css';
 ```
 

--- a/integration/src/index.tsx
+++ b/integration/src/index.tsx
@@ -7,9 +7,6 @@ import {
     AccordionItemPanel,
 } from '../../src';
 
-// tslint:disable-next-line no-import-side-effect
-import '../../src/css/minimal-example.css';
-
 ReactDOM.render(
     <div id="classic-accordion">
         <Accordion>

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -3,14 +3,6 @@
 * Demo styles
 * ----------------------------------------------
 **/
-.u-position-absolute {
-    position: absolute;
-}
-
-.u-position-relative {
-    position: relative;
-}
-
 .accordion {
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 2px;

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -40,12 +40,7 @@
 
 .accordion__panel {
     padding: 20px;
-    display: none;
     animation: fadein 0.35s ease-in;
-}
-
-.accordion__panel--expanded {
-    display: block;
 }
 
 .accordion__heading > *:last-child,

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -12,10 +12,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.accordion__item--has-icon {
-    position: relative;
-}
-
 .accordion__heading {
     background-color: #f4f4f4;
     color: #444;
@@ -132,14 +128,4 @@
     100% {
         transform: translateY(0);
     }
-}
-
-.accordion__heading--animated:hover .accordion__arrow {
-    animation-name: move-down;
-    animation-duration: 1.5s;
-}
-
-.accordion__heading--animated[aria-expanded='true']:hover .accordion__arrow {
-    animation-name: move-up;
-    animation-duration: 1.5s;
 }

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -93,39 +93,3 @@
         opacity: 1;
     }
 }
-
-@keyframes move-down {
-    0% {
-        transform: translateY(0);
-    }
-    10% {
-        transform: translateY(0);
-    }
-    20% {
-        transform: translateY(5px);
-    }
-    30% {
-        transform: translateY(0);
-    }
-    100% {
-        transform: translateY(0);
-    }
-}
-
-@keyframes move-up {
-    0% {
-        transform: translateY(0);
-    }
-    10% {
-        transform: translateY(0);
-    }
-    20% {
-        transform: translateY(-5px);
-    }
-    30% {
-        transform: translateY(0);
-    }
-    100% {
-        transform: translateY(0);
-    }
-}

--- a/src/css/minimal-example.css
+++ b/src/css/minimal-example.css
@@ -1,7 +1,0 @@
-.accordion__panel {
-    display: none;
-}
-
-.accordion__panel--expanded {
-    display: block;
-}

--- a/src/helpers/AccordionStore.ts
+++ b/src/helpers/AccordionStore.ts
@@ -5,6 +5,7 @@ export interface InjectedPanelAttributes {
     'aria-hidden': boolean | undefined;
     'aria-labelledby': string;
     id: string;
+    hidden: boolean | undefined; // Any string value is interpreted as 'true'.
 }
 
 export interface InjectedHeadingAttributes {
@@ -90,6 +91,7 @@ export default class AccordionStore {
             'aria-hidden': this.allowMultipleExpanded ? !expanded : undefined,
             'aria-labelledby': this.getHeadingId(uuid),
             id: this.getPanelId(uuid),
+            hidden: expanded ? undefined : true,
         };
     };
 


### PR DESCRIPTION
Adds the 'hidden' attribute to panel divs. Vendor styles applied by browsers hide elements with this attribute, which makes `minimal-example.css` entirely redundant, because the library now 'functions' (hides and shows panels) even without additional styling.

To re-surface an old debate though... Should we even be publishing styles with this library? Now that we have _this_, it's not strictly necessary to even apply any additional styles at all. It was not inconvenient to publish the 'fancy-example' until now because it was just the styles that we used on the demo page, which were/are quite bootstrap-y and generic, but I would like to completely redesign that page soon, which could make them a bigger maintenance overhead.