### PR TITLE
Chore/heading and button components

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ Class(es) to apply to the 'heading' element.
 
 #### buttonClassName : `string` [*optional*, default: `'accordion__button'`]
 
-Class(es) to apply to the 'heading' element.
+Class(es) to apply to the 'button' element.
+
+#### aria-level : `number` [*optional*, default: `3`]
+
+Semantics to apply to the 'heading' element. A value of `1` would make your
+heading element hierarchically equivalent to an `<h1>` tag, and likewise a value
+of `6` would make it equivalent to an `<h6>` tag.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ of `6` would make it equivalent to an `<h6>` tag.
 
 ### AccordionItemButton
 
-#### className : `string` [*optional*, default: `'accordion__heading'`]
+#### className : `string` [*optional*, default: `'accordion__button'`]
 
-Class(es) to apply to the 'heading' element.
+Class(es) to apply to the 'button' element.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ export default function Example() {
         <Accordion>
             <AccordionItem>
                 <AccordionItemHeading>
-                    <span className="accordion__arrow" role="presentation" />
-                    What harsh truths do you prefer to ignore?
+                    <AccordionItemButton>
+                        What harsh truths do you prefer to ignore?
+                    </AccordionItemButton>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>
@@ -53,8 +54,9 @@ export default function Example() {
             </AccordionItem>
             <AccordionItem>
                 <AccordionItemHeading>
-                    <span className="accordion__arrow" role="presentation" />
-                    Is free will real or just an illusion?
+                    <AccordionItemButton>
+                        Is free will real or just an illusion?
+                    </AccordionItemButton>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>
@@ -118,19 +120,21 @@ Recommended for use with `onChange`. Will be auto-generated if not provided.
 
 ### AccordionItemHeading
 
-#### headingClassName : `string` [*optional*, default: `'accordion__heading'`]
+#### className : `string` [*optional*, default: `'accordion__heading'`]
 
 Class(es) to apply to the 'heading' element.
-
-#### buttonClassName : `string` [*optional*, default: `'accordion__button'`]
-
-Class(es) to apply to the 'button' element.
 
 #### aria-level : `number` [*optional*, default: `3`]
 
 Semantics to apply to the 'heading' element. A value of `1` would make your
 heading element hierarchically equivalent to an `<h1>` tag, and likewise a value
 of `6` would make it equivalent to an `<h6>` tag.
+
+### AccordionItemButton
+
+#### className : `string` [*optional*, default: `'accordion__heading'`]
+
+Class(es) to apply to the 'heading' element.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ Callback which is invoked when items are expanded or collapsed. Gets passed
 
 Class(es) to apply to element.
 
-#### expandedClassName : `string` [*optional*, default: `accordion__item--expanded`]
-
-Class(es) to append when item is expanded.
-
 #### uuid : `string|number` [*optional*]
 
 Recommended for use with `onChange`. Will be auto-generated if not provided.
@@ -122,13 +118,13 @@ Recommended for use with `onChange`. Will be auto-generated if not provided.
 
 ### AccordionItemHeading
 
-#### className : `string` [*optional*, default: `'accordion__heading'`]
+#### headingClassName : `string` [*optional*, default: `'accordion__heading'`]
 
-Class(es) to apply to element.
+Class(es) to apply to the 'heading' element.
 
-#### expandedClassName : `string` [*optional*, default: `'accordion__heading--expanded'`]
+#### buttonClassName : `string` [*optional*, default: `'accordion__button'`]
 
-Class(es) to append when item is expanded.
+Class(es) to apply to the 'heading' element.
 
 ---
 
@@ -137,10 +133,6 @@ Class(es) to append when item is expanded.
 #### className : `string` [*optional*, default: `'accordion__panel'`]
 
 Class(es) to apply to element.
-
-#### expandedClassName : `string` [*optional*, default: `'accordion__panel'`]
-
-Class(es) to append when item is expanded.
 
 ---
 

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -7,6 +7,7 @@ import placeholders, { Placeholder } from './placeholders';
 import {
     Accordion,
     AccordionItem,
+    AccordionItemButton,
     AccordionItemHeading,
     AccordionItemPanel,
 } from '../../src';
@@ -49,8 +50,10 @@ const App = (): JSX.Element => (
             {placeholders.map((placeholder: Placeholder) => (
                 <AccordionItem key={placeholder.heading}>
                     <AccordionItemHeading>
-                        <Arrow />
-                        {placeholder.heading}
+                        <AccordionItemButton>
+                            <Arrow />
+                            {placeholder.heading}
+                        </AccordionItemButton>
                     </AccordionItemHeading>
                     <AccordionItemPanel>{placeholder.panel}</AccordionItemPanel>
                 </AccordionItem>
@@ -69,8 +72,10 @@ const App = (): JSX.Element => (
             {placeholders.map((placeholder: Placeholder) => (
                 <AccordionItem key={placeholder.heading}>
                     <AccordionItemHeading>
-                        <Arrow />
-                        {placeholder.heading}
+                        <AccordionItemButton>
+                            <Arrow />
+                            {placeholder.heading}
+                        </AccordionItemButton>
                     </AccordionItemHeading>
                     <AccordionItemPanel>{placeholder.panel}</AccordionItemPanel>
                 </AccordionItem>
@@ -89,8 +94,10 @@ const App = (): JSX.Element => (
             {placeholders.map((placeholder: Placeholder) => (
                 <AccordionItem key={placeholder.heading}>
                     <AccordionItemHeading>
-                        <Arrow />
-                        {placeholder.heading}
+                        <AccordionItemButton>
+                            <Arrow />
+                            {placeholder.heading}
+                        </AccordionItemButton>
                     </AccordionItemHeading>
                     <AccordionItemPanel>{placeholder.panel}</AccordionItemPanel>
                 </AccordionItem>
@@ -117,8 +124,10 @@ const App = (): JSX.Element => (
                     uuid={placeholder.uuid}
                 >
                     <AccordionItemHeading>
-                        <Arrow />
-                        {placeholder.heading}
+                        <AccordionItemButton>
+                            <Arrow />
+                            {placeholder.heading}
+                        </AccordionItemButton>
                     </AccordionItemHeading>
                     <AccordionItemPanel>{placeholder.panel}</AccordionItemPanel>
                 </AccordionItem>
@@ -151,8 +160,10 @@ const App = (): JSX.Element => (
                     uuid={placeholder.uuid}
                 >
                     <AccordionItemHeading>
-                        <Arrow />
-                        {placeholder.heading}
+                        <AccordionItemButton>
+                            <Arrow />
+                            {placeholder.heading}
+                        </AccordionItemButton>
                     </AccordionItemHeading>
                     <AccordionItemPanel>{placeholder.panel}</AccordionItemPanel>
                 </AccordionItem>
@@ -164,8 +175,10 @@ const App = (): JSX.Element => (
         <Accordion>
             <AccordionItem>
                 <AccordionItemHeading>
-                    <Arrow />
-                    Render something different when expanded
+                    <AccordionItemButton>
+                        <Arrow />
+                        Render something different when expanded
+                    </AccordionItemButton>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>
@@ -176,8 +189,10 @@ const App = (): JSX.Element => (
             </AccordionItem>
             <AccordionItem>
                 <AccordionItemHeading>
-                    <Arrow />
-                    How to?
+                    <AccordionItemButton>
+                        <Arrow />
+                        How to?
+                    </AccordionItemButton>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -18,10 +18,6 @@ import './main.css';
 // tslint:disable-next-line no-import-side-effect ordered-imports
 import '../../src/css/fancy-example.css';
 
-const Arrow = (): JSX.Element => (
-    <span className="accordion__arrow" role="presentation" />
-);
-
 // tslint:disable-next-line max-func-body-length
 const App = (): JSX.Element => (
     <div className="demo-container">
@@ -51,7 +47,6 @@ const App = (): JSX.Element => (
                 <AccordionItem key={placeholder.heading}>
                     <AccordionItemHeading>
                         <AccordionItemButton>
-                            <Arrow />
                             {placeholder.heading}
                         </AccordionItemButton>
                     </AccordionItemHeading>
@@ -73,7 +68,6 @@ const App = (): JSX.Element => (
                 <AccordionItem key={placeholder.heading}>
                     <AccordionItemHeading>
                         <AccordionItemButton>
-                            <Arrow />
                             {placeholder.heading}
                         </AccordionItemButton>
                     </AccordionItemHeading>
@@ -95,7 +89,6 @@ const App = (): JSX.Element => (
                 <AccordionItem key={placeholder.heading}>
                     <AccordionItemHeading>
                         <AccordionItemButton>
-                            <Arrow />
                             {placeholder.heading}
                         </AccordionItemButton>
                     </AccordionItemHeading>
@@ -125,7 +118,6 @@ const App = (): JSX.Element => (
                 >
                     <AccordionItemHeading>
                         <AccordionItemButton>
-                            <Arrow />
                             {placeholder.heading}
                         </AccordionItemButton>
                     </AccordionItemHeading>
@@ -161,7 +153,6 @@ const App = (): JSX.Element => (
                 >
                     <AccordionItemHeading>
                         <AccordionItemButton>
-                            <Arrow />
                             {placeholder.heading}
                         </AccordionItemButton>
                     </AccordionItemHeading>
@@ -176,7 +167,6 @@ const App = (): JSX.Element => (
             <AccordionItem>
                 <AccordionItemHeading>
                     <AccordionItemButton>
-                        <Arrow />
                         Render something different when expanded
                     </AccordionItemButton>
                 </AccordionItemHeading>
@@ -189,10 +179,7 @@ const App = (): JSX.Element => (
             </AccordionItem>
             <AccordionItem>
                 <AccordionItemHeading>
-                    <AccordionItemButton>
-                        <Arrow />
-                        How to?
-                    </AccordionItemButton>
+                    <AccordionItemButton>How to?</AccordionItemButton>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
                     <p>

--- a/integration/src/index.tsx
+++ b/integration/src/index.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom';
 import {
     Accordion,
     AccordionItem,
+    AccordionItemButton,
     AccordionItemHeading,
     AccordionItemPanel,
 } from '../../src';
@@ -11,7 +12,9 @@ ReactDOM.render(
     <div id="classic-accordion">
         <Accordion>
             <AccordionItem>
-                <AccordionItemHeading>Heading One</AccordionItemHeading>
+                <AccordionItemHeading>
+                    <AccordionItemButton>Heading One</AccordionItemButton>
+                </AccordionItemHeading>
                 <AccordionItemPanel>
                     Sunt in reprehenderit cillum ex proident qui culpa fugiat
                     pariatur aliqua nostrud consequat consequat enim quis sit
@@ -20,7 +23,9 @@ ReactDOM.render(
                 </AccordionItemPanel>
             </AccordionItem>
             <AccordionItem>
-                <AccordionItemHeading>Heading Two</AccordionItemHeading>
+                <AccordionItemHeading>
+                    <AccordionItemButton>Heading Two</AccordionItemButton>
+                </AccordionItemHeading>
                 <AccordionItemPanel>
                     Velit tempor dolore commodo voluptate id do nulla do ut
                     proident cillum ad cillum voluptate deserunt fugiat ut sed
@@ -29,7 +34,9 @@ ReactDOM.render(
                 </AccordionItemPanel>
             </AccordionItem>
             <AccordionItem>
-                <AccordionItemHeading>Heading Three</AccordionItemHeading>
+                <AccordionItemHeading>
+                    <AccordionItemButton>Heading Three</AccordionItemButton>
+                </AccordionItemHeading>
                 <AccordionItemPanel>
                     Lorem ipsum esse occaecat voluptate duis incididunt amet
                     eiusmod sunt commodo sunt enim anim ea culpa ut tempor

--- a/integration/wai-aria.spec.js
+++ b/integration/wai-aria.spec.js
@@ -279,7 +279,7 @@ describe('WAI ARIA Spec', () => {
         xit(`If the native host language has an element with an implicit
             heading and aria-level, such as an HTML heading tag, a native host
             language element may be used.`, () => {
-            // todo
+            // Not applicable.
         });
 
         xit(`The button element is the only element inside the heading element.

--- a/integration/wai-aria.spec.js
+++ b/integration/wai-aria.spec.js
@@ -132,7 +132,7 @@ describe('WAI ARIA Spec', () => {
                 await firstButtonHandle.focus();
                 await page.keyboard.press('Tab');
                 const secondIsFocussed = await page.evaluate(
-                    heading => document.activeElement === heading,
+                    button => document.activeElement === button,
                     secondButtonHandle,
                 );
                 expect(secondIsFocussed).toEqual(true);
@@ -150,7 +150,7 @@ describe('WAI ARIA Spec', () => {
                 await page.keyboard.press('Tab');
                 await page.keyboard.up('Shift');
                 const firstIsFocussed = await page.evaluate(
-                    heading => document.activeElement === heading,
+                    button => document.activeElement === button,
                     firstButtonHandle,
                 );
                 expect(firstIsFocussed).toEqual(true);
@@ -165,7 +165,7 @@ describe('WAI ARIA Spec', () => {
                 await firstButtonHandle.focus();
                 await page.keyboard.press('ArrowDown');
                 const secondIsFocussed = await page.evaluate(
-                    heading => document.activeElement === heading,
+                    button => document.activeElement === button,
                     secondButtonHandle,
                 );
                 expect(secondIsFocussed).toEqual(true);
@@ -185,7 +185,7 @@ describe('WAI ARIA Spec', () => {
                 await secondButtonHandle.focus();
                 await page.keyboard.press('ArrowUp');
                 const firstIsFocussed = await page.evaluate(
-                    heading => document.activeElement === heading,
+                    button => document.activeElement === button,
                     firstButtonHandle,
                 );
                 expect(firstIsFocussed).toEqual(true);
@@ -209,7 +209,7 @@ describe('WAI ARIA Spec', () => {
                 await thirdButtonHandle.focus();
                 await page.keyboard.press('Home');
                 const firstIsFocussed = await page.evaluate(
-                    heading => document.activeElement === heading,
+                    button => document.activeElement === button,
                     firstButtonHandle,
                 );
                 expect(firstIsFocussed).toEqual(true);
@@ -228,7 +228,7 @@ describe('WAI ARIA Spec', () => {
                 await firstButtonHandle.focus();
                 await page.keyboard.press('End');
                 const thirdIsFocussed = await page.evaluate(
-                    heading => document.activeElement === heading,
+                    button => document.activeElement === button,
                     thirdButtonHandle,
                 );
                 expect(thirdIsFocussed).toEqual(true);

--- a/integration/wai-aria.spec.js
+++ b/integration/wai-aria.spec.js
@@ -282,10 +282,31 @@ describe('WAI ARIA Spec', () => {
             // Not applicable.
         });
 
-        xit(`The button element is the only element inside the heading element.
+        it(`The button element is the only element inside the heading element.
             That is, if there are other visually persistent elements, they are
-            not included inside the heading element.`, () => {
-            // todo
+            not included inside the heading element.`, async () => {
+            const { headingsHandles, page } = await setup();
+
+            expect(headingsHandles).toHaveLength(3);
+
+            for (const handle of headingsHandles) {
+                expect(
+                    await page.evaluate(
+                        heading => heading.childNodes.length === 1,
+                        handle,
+                    ),
+                ).toEqual(true);
+
+                expect(
+                    await page.evaluate(
+                        heading =>
+                            heading.firstChild.getAttribute(
+                                'data-accordion-component',
+                            ) === 'AccordionItemButton',
+                        handle,
+                    ),
+                ).toEqual(true);
+            }
         });
 
         it(`If the accordion panel associated with an accordion header is

--- a/integration/wai-aria.spec.js
+++ b/integration/wai-aria.spec.js
@@ -253,10 +253,27 @@ describe('WAI ARIA Spec', () => {
             }
         });
 
-        xit(`Each accordion header button is wrapped in an element with role
+        it(`Each accordion header button is wrapped in an element with role
             heading that has a value set for aria-level that is appropriate for
-            the information architecture of the page.`, () => {
-            // Not yet supported.
+            the information architecture of the page.`, async () => {
+            const { browser, page, buttonsHandles } = await setup();
+            expect(buttonsHandles).toHaveLength(3);
+            for (const buttonHandle of buttonsHandles) {
+                expect(
+                    await page.evaluate(
+                        button => button.parentElement.getAttribute('role'),
+                        buttonHandle,
+                    ),
+                ).toBe('heading');
+
+                expect(
+                    await page.evaluate(
+                        button =>
+                            button.parentElement.getAttribute('aria-level'),
+                        buttonHandle,
+                    ),
+                ).toBeTruthy();
+            }
         });
 
         xit(`If the native host language has an element with an implicit

--- a/integration/wai-aria.spec.js
+++ b/integration/wai-aria.spec.js
@@ -2,8 +2,16 @@ import path from 'path';
 import puppeteer from 'puppeteer';
 
 describe('WAI ARIA Spec', () => {
+    let browser;
+
+    afterEach(async () => {
+        if (browser && browser.close) {
+            await browser.close();
+        }
+    });
+
     async function setup() {
-        const browser = await puppeteer.launch({
+        browser = await puppeteer.launch({
             headless: true,
             args: [
                 '--no-sandbox',
@@ -20,16 +28,23 @@ describe('WAI ARIA Spec', () => {
 
         // Seems like the browser is a bit slower on CI, and we're trying to
         // select headings before they're registered in the 'store'.
-        await page.waitForSelector('.accordion__heading');
+        await page.waitForSelector(
+            '[data-accordion-component="AccordionItemHeading"]',
+        );
 
         const headingsHandles = await page.$$(
-            '#classic-accordion .accordion__heading',
-        );
-        const itemsHandles = await page.$$(
-            '#classic-accordion .accordion__item',
+            '#classic-accordion [data-accordion-component="AccordionItemHeading"]',
         );
 
-        return { browser, page, headingsHandles, itemsHandles };
+        const buttonsHandles = await page.$$(
+            '#classic-accordion [data-accordion-component="AccordionItemButton"]',
+        );
+
+        const itemsHandles = await page.$$(
+            '#classic-accordion [data-accordion-component="AccordionItem"]',
+        );
+
+        return { browser, page, headingsHandles, buttonsHandles, itemsHandles };
     }
 
     describe('Canary tests', () => {
@@ -39,8 +54,6 @@ describe('WAI ARIA Spec', () => {
             expect(title).toBe(
                 'React Accessible Accordion - Integration Test Sandbox',
             );
-
-            await browser.close();
         });
         it('has rendered the "classic accordion" example', async () => {
             const { browser, page } = await setup();
@@ -48,8 +61,6 @@ describe('WAI ARIA Spec', () => {
                 () => document.querySelectorAll('#classic-accordion').length,
             );
             expect(qtyClassicAccordion).toEqual(1);
-
-            await browser.close();
         });
     });
 
@@ -57,222 +68,220 @@ describe('WAI ARIA Spec', () => {
         it('matches snapshots', async () => {
             const { browser, page } = await setup();
             expect(await page.accessibility.snapshot()).toMatchSnapshot();
-
-            await browser.close();
         });
     });
 
     describe('Keyboard Interaction', () => {
         describe('Enter or Space', () => {
-            it('When focus is on the accordion header for a collapsed panel, expands the associated panel. If the implementation allows only one panel to be expanded, and if another panel is expanded, collapses that panel.', async () => {
-                const { browser, page, headingsHandles } = await setup();
-                expect(headingsHandles.length).toEqual(3);
+            it(`When focus is on the accordion header for a collapsed panel,
+                expands the associated panel. If the implementation allows only
+                one panel to be expanded, and if another panel is expanded,
+                collapses that panel.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
+                expect(buttonsHandles.length).toEqual(3);
 
-                const firstHeadingHandle = headingsHandles[0];
-                const secondHeadingHandle = headingsHandles[1];
+                const firstButtonHandle = buttonsHandles[0];
+                const secondButtonHandle = buttonsHandles[1];
 
-                function evaluateIsExpanded(headingHandle) {
+                function evaluateIsExpanded(buttonHandle) {
                     return page
                         .evaluate(
                             heading => heading.getAttribute('aria-expanded'),
-                            headingHandle,
+                            buttonHandle,
                         )
                         .then(ariaExpanded => ariaExpanded === 'true');
                 }
 
                 // ENTER key
-                await firstHeadingHandle.focus();
-                expect(await evaluateIsExpanded(firstHeadingHandle)).toEqual(
+                await firstButtonHandle.focus();
+                expect(await evaluateIsExpanded(firstButtonHandle)).toEqual(
                     false,
                 );
                 await page.keyboard.press('Enter');
-                expect(await evaluateIsExpanded(firstHeadingHandle)).toEqual(
+                expect(await evaluateIsExpanded(firstButtonHandle)).toEqual(
                     true,
                 );
 
                 // SPACE key
-                await secondHeadingHandle.focus();
-                expect(await evaluateIsExpanded(secondHeadingHandle)).toEqual(
+                await secondButtonHandle.focus();
+                expect(await evaluateIsExpanded(secondButtonHandle)).toEqual(
                     false,
                 );
                 await page.keyboard.press('Space');
-                expect(await evaluateIsExpanded(secondHeadingHandle)).toEqual(
+                expect(await evaluateIsExpanded(secondButtonHandle)).toEqual(
                     true,
                 );
-
-                await browser.close();
             });
 
-            xit('When focus is on the accordion header for an expanded panel, collapses the panel if the implementation supports collapsing. Some implementations require one panel to be expanded at all times and allow only one panel to be expanded; so, they do not support a collapse function.', () => {
+            xit(`When focus is on the accordion header for an expanded panel,
+                collapses the panel if the implementation supports collapsing.
+                Some implementations require one panel to be expanded at all
+                times and allow only one panel to be expanded; so, they do not
+                support a collapse function.`, () => {
                 // todo
             });
         });
 
         describe('Tab', () => {
-            it('Moves focus to the next focusable element; all focusable elements in the accordion are included in the page Tab sequence.', async () => {
-                const { browser, page, headingsHandles } = await setup();
+            it(`Moves focus to the next focusable element; all focusable
+                elements in the accordion are included in the page Tab
+                sequence.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
 
-                const [
-                    firstHeadingHandle,
-                    secondHeadingHandle,
-                ] = headingsHandles;
-                await firstHeadingHandle.focus();
+                const [firstButtonHandle, secondButtonHandle] = buttonsHandles;
+                await firstButtonHandle.focus();
                 await page.keyboard.press('Tab');
                 const secondIsFocussed = await page.evaluate(
                     heading => document.activeElement === heading,
-                    secondHeadingHandle,
+                    secondButtonHandle,
                 );
                 expect(secondIsFocussed).toEqual(true);
-
-                await browser.close();
             });
         });
 
         describe('Shift + Tab', () => {
-            it('Moves focus to the previous focusable element; all focusable elements in the accordion are included in the page Tab sequence.', async () => {
-                const { browser, page, headingsHandles } = await setup();
-                const [
-                    firstHeadingHandle,
-                    secondHeadingHandle,
-                ] = headingsHandles;
-                await secondHeadingHandle.focus();
+            it(`Moves focus to the previous focusable element; all focusable
+                elements in the accordion are included in the page Tab
+                sequence.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
+                const [firstButtonHandle, secondButtonHandle] = buttonsHandles;
+                await secondButtonHandle.focus();
                 await page.keyboard.down('Shift');
                 await page.keyboard.press('Tab');
                 await page.keyboard.up('Shift');
                 const firstIsFocussed = await page.evaluate(
                     heading => document.activeElement === heading,
-                    firstHeadingHandle,
+                    firstButtonHandle,
                 );
                 expect(firstIsFocussed).toEqual(true);
-
-                await browser.close();
             });
         });
 
         describe('Down Arrow (Optional)', () => {
-            it('If focus is on an accordion header, moves focus to the next accordion header.', async () => {
-                const { browser, page, headingsHandles } = await setup();
-                const [
-                    firstHeadingHandle,
-                    secondHeadingHandle,
-                ] = headingsHandles;
-                await firstHeadingHandle.focus();
+            it(`If focus is on an accordion header, moves focus to the next
+                accordion header.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
+                const [firstButtonHandle, secondButtonHandle] = buttonsHandles;
+                await firstButtonHandle.focus();
                 await page.keyboard.press('ArrowDown');
                 const secondIsFocussed = await page.evaluate(
                     heading => document.activeElement === heading,
-                    secondHeadingHandle,
+                    secondButtonHandle,
                 );
                 expect(secondIsFocussed).toEqual(true);
-
-                await browser.close();
             });
 
-            xit('If focus is on the last accordion header, either does nothing or moves focus to the first accordion header.', () => {
+            xit(`If focus is on the last accordion header, either does nothing
+                or moves focus to the first accordion header.`, () => {
                 // todo
             });
         });
 
         describe('Up Arrow (Optional)', () => {
-            it('If focus is on an accordion header, moves focus to the previous accordion header.', async () => {
-                const { browser, page, headingsHandles } = await setup();
-                const [
-                    firstHeadingHandle,
-                    secondHeadingHandle,
-                ] = headingsHandles;
-                await secondHeadingHandle.focus();
+            it(`If focus is on an accordion header, moves focus to the previous
+                accordion header.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
+                const [firstButtonHandle, secondButtonHandle] = buttonsHandles;
+                await secondButtonHandle.focus();
                 await page.keyboard.press('ArrowUp');
                 const firstIsFocussed = await page.evaluate(
                     heading => document.activeElement === heading,
-                    firstHeadingHandle,
+                    firstButtonHandle,
                 );
                 expect(firstIsFocussed).toEqual(true);
-
-                await browser.close();
             });
 
-            xit('If focus is on the first accordion header, either does nothing or moves focus to the last accordion header.', () => {
+            xit(`If focus is on the first accordion header, either does nothing
+                or moves focus to the last accordion header.`, () => {
                 // todo
             });
         });
 
         describe('Home (Optional)', () => {
-            it('When focus is on an accordion header, moves focus to the first accordion header.', async () => {
-                const { browser, page, headingsHandles } = await setup();
+            it(`When focus is on an accordion header, moves focus to the first
+                accordion header.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
                 const [
-                    firstHeadingHandle,
-                    secondHeadingHandle,
-                    thirdHeadingHandle,
-                ] = headingsHandles;
-                await thirdHeadingHandle.focus();
+                    firstButtonHandle,
+                    secondButtonHandle,
+                    thirdButtonHandle,
+                ] = buttonsHandles;
+                await thirdButtonHandle.focus();
                 await page.keyboard.press('Home');
                 const firstIsFocussed = await page.evaluate(
                     heading => document.activeElement === heading,
-                    firstHeadingHandle,
+                    firstButtonHandle,
                 );
                 expect(firstIsFocussed).toEqual(true);
-
-                await browser.close();
             });
         });
 
         describe('End (Optional)', () => {
-            it('When focus is on an accordion header, moves focus to the last accordion header.', async () => {
-                const { browser, page, headingsHandles } = await setup();
+            it(`When focus is on an accordion header, moves focus to the last
+                accordion header.`, async () => {
+                const { browser, page, buttonsHandles } = await setup();
                 const [
-                    firstHeadingHandle,
-                    secondHeadingHandle,
-                    thirdHeadingHandle,
-                ] = headingsHandles;
-                await firstHeadingHandle.focus();
+                    firstButtonHandle,
+                    secondButtonHandle,
+                    thirdButtonHandle,
+                ] = buttonsHandles;
+                await firstButtonHandle.focus();
                 await page.keyboard.press('End');
                 const thirdIsFocussed = await page.evaluate(
                     heading => document.activeElement === heading,
-                    thirdHeadingHandle,
+                    thirdButtonHandle,
                 );
                 expect(thirdIsFocussed).toEqual(true);
-
-                await browser.close();
             });
         });
     });
 
     describe('WAI-ARIA Roles, States, and Properties', () => {
-        it('The title of each accordion header is contained in an element with role button.', async () => {
-            const { browser, page, headingsHandles } = await setup();
-            expect(headingsHandles).toHaveLength(3);
-            for (const headingHandle of headingsHandles) {
+        it(`The title of each accordion header is contained in an element with
+            role button.`, async () => {
+            // TODO: Use 'title' elements inside the headings.
+
+            const { browser, page, buttonsHandles } = await setup();
+            expect(buttonsHandles).toHaveLength(3);
+            for (const buttonHandle of buttonsHandles) {
                 expect(
                     await page.evaluate(
-                        heading => heading.getAttribute('role'),
-                        headingHandle,
+                        button => button.getAttribute('role'),
+                        buttonHandle,
                     ),
                 ).toBe('button');
             }
-
-            await browser.close();
         });
 
-        xit('Each accordion header button is wrapped in an element with role heading that has a value set for aria-level that is appropriate for the information architecture of the page.', () => {
+        xit(`Each accordion header button is wrapped in an element with role
+            heading that has a value set for aria-level that is appropriate for
+            the information architecture of the page.`, () => {
             // Not yet supported.
         });
 
-        xit('If the native host language has an element with an implicit heading and aria-level, such as an HTML heading tag, a native host language element may be used.', () => {
+        xit(`If the native host language has an element with an implicit
+            heading and aria-level, such as an HTML heading tag, a native host
+            language element may be used.`, () => {
             // todo
         });
 
-        xit('The button element is the only element inside the heading element. That is, if there are other visually persistent elements, they are not included inside the heading element.', () => {
+        xit(`The button element is the only element inside the heading element.
+            That is, if there are other visually persistent elements, they are
+            not included inside the heading element.`, () => {
             // todo
         });
 
-        it('If the accordion panel associated with an accordion header is visible, the header button element has aria-expanded set to true. If the panel is not visible, aria-expanded is set to false.', async () => {
-            const { browser, page, headingsHandles } = await setup();
-            expect(headingsHandles.length).toEqual(3);
+        it(`If the accordion panel associated with an accordion header is
+            visible, the header button element has aria-expanded set to true.
+            If the panel is not visible, aria-expanded is set to false.`, async () => {
+            const { browser, page, buttonsHandles } = await setup();
+            expect(buttonsHandles.length).toEqual(3);
 
-            for (const handle of headingsHandles) {
+            for (const handle of buttonsHandles) {
                 // Before expanding
                 expect(
                     await page.evaluate(
-                        heading => heading.getAttribute('aria-expanded'),
+                        button => button.getAttribute('aria-expanded'),
                         handle,
                     ),
                 ).toEqual('false');
@@ -283,68 +292,75 @@ describe('WAI ARIA Spec', () => {
                 // After expanding
                 expect(
                     await page.evaluate(
-                        heading => heading.getAttribute('aria-expanded'),
+                        button => button.getAttribute('aria-expanded'),
                         handle,
                     ),
                 ).toEqual('true');
             }
-
-            await browser.close();
         });
 
-        it('The accordion header button element has aria-controls set to the ID of the element containing the accordion panel content.', async () => {
+        it(`The accordion header button element has aria-controls set to the ID
+            of the element containing the accordion panel content.`, async () => {
             const { browser, page, itemsHandles } = await setup();
             expect(itemsHandles.length).toEqual(3);
 
             for (const itemHandle of itemsHandles) {
-                const headingHandle = await itemHandle.$('.accordion__heading');
-                const panelHandle = await itemHandle.$('.accordion__panel');
+                const buttonHandle = await itemHandle.$(
+                    '[data-accordion-component="AccordionItemButton"]',
+                );
+                const panelHandle = await itemHandle.$(
+                    '[data-accordion-component="AccordionItemPanel"]',
+                );
 
-                const headingAriaControls = await page.evaluate(
-                    heading => heading.getAttribute('aria-controls'),
-                    headingHandle,
+                const buttonAriaControls = await page.evaluate(
+                    button => button.getAttribute('aria-controls'),
+                    buttonHandle,
                 );
                 const panelId = await page.evaluate(
                     panel => panel.id,
                     panelHandle,
                 );
 
-                expect(headingAriaControls).toBeTruthy();
+                expect(buttonAriaControls).toBeTruthy();
                 expect(panelId).toBeTruthy();
-                expect(headingAriaControls).toEqual(panelId);
+                expect(buttonAriaControls).toEqual(panelId);
             }
-
-            await browser.close();
         });
 
-        it('If the accordion panel associated with an accordion header is visible, and if the accordion does not permit the panel to be collapsed, the header button element has aria-disabled set to true.', async () => {
-            const { browser, page, headingsHandles } = await setup();
-            expect(headingsHandles.length).toEqual(3);
+        it(`If the accordion panel associated with an accordion header is
+            visible, and if the accordion does not permit the panel to be
+            collapsed, the header button element has aria-disabled set to true.`, async () => {
+            const { browser, page, buttonsHandles } = await setup();
+            expect(buttonsHandles.length).toEqual(3);
 
-            const [firstHeadingHandle] = headingsHandles;
-            await firstHeadingHandle.click();
+            const [firstButtonHandle] = buttonsHandles;
+            await firstButtonHandle.click();
 
-            const headingAriaDisabled = await page.evaluate(
-                heading => heading.getAttribute('aria-disabled'),
-                firstHeadingHandle,
+            const buttonAriaDisabled = await page.evaluate(
+                button => button.getAttribute('aria-disabled'),
+                firstButtonHandle,
             );
 
-            expect(headingAriaDisabled).toEqual('true');
-
-            await browser.close();
+            expect(buttonAriaDisabled).toEqual('true');
         });
 
-        it('Optionally, each element that serves as a container for panel content has role region and aria-labelledby with a value that refers to the button that controls display of the panel.', async () => {
+        it(`Optionally, each element that serves as a container for panel
+            content has role region and aria-labelledby with a value that refers
+            to the button that controls display of the panel.`, async () => {
             const { browser, page, itemsHandles } = await setup();
             expect(itemsHandles.length).toEqual(3);
 
             for (const itemHandle of itemsHandles) {
-                const headingHandle = await itemHandle.$('.accordion__heading');
-                const panelHandle = await itemHandle.$('.accordion__panel');
+                const buttonHandle = await itemHandle.$(
+                    '[data-accordion-component="AccordionItemButton"]',
+                );
+                const panelHandle = await itemHandle.$(
+                    '[data-accordion-component="AccordionItemPanel"]',
+                );
 
-                const headingId = await page.evaluate(
-                    heading => heading.id,
-                    headingHandle,
+                const buttonId = await page.evaluate(
+                    button => button.id,
+                    buttonHandle,
                 );
                 const panelAriaLabelledBy = await page.evaluate(
                     panel => panel.getAttribute('aria-labelledby'),
@@ -356,13 +372,11 @@ describe('WAI ARIA Spec', () => {
                 );
 
                 expect(panelAriaLabelledBy).toBeTruthy();
-                expect(headingId).toBeTruthy();
+                expect(buttonId).toBeTruthy();
 
-                expect(panelAriaLabelledBy).toEqual(headingId);
+                expect(panelAriaLabelledBy).toEqual(buttonId);
                 expect(panelRole).toEqual('region');
             }
-
-            await browser.close();
         });
     });
 });

--- a/src/components/Accordion.spec.tsx
+++ b/src/components/Accordion.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { cleanup, fireEvent, render } from 'react-testing-library';
 import { default as Accordion } from './Accordion';
 import AccordionItem from './AccordionItem';
+import AccordionItemButton from './AccordionItemButton';
 import AccordionItemHeading from './AccordionItemHeading';
 
 enum UUIDS {
@@ -42,10 +43,14 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion allowMultipleExpanded={true}>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.BAR} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.BAR} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -65,10 +70,14 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.BAR} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.BAR} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -90,7 +99,9 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion allowZeroExpanded={true}>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -107,7 +118,9 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -126,7 +139,9 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion preExpanded={[UUIDS.FOO]}>
                         <AccordionItem uuid={UUIDS.FOO}>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -140,7 +155,9 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion>
                         <AccordionItem>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -157,7 +174,9 @@ describe('Accordion', () => {
                 const { getByTestId } = render(
                     <Accordion onChange={onChange}>
                         <AccordionItem uuid={UUIDS.FOO}>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );
@@ -176,7 +195,9 @@ describe('Accordion', () => {
                         allowZeroExpanded={true}
                     >
                         <AccordionItem uuid={UUIDS.FOO}>
-                            <AccordionItemHeading data-testid={UUIDS.FOO} />
+                            <AccordionItemHeading>
+                                <AccordionItemButton data-testid={UUIDS.FOO} />
+                            </AccordionItemHeading>
                         </AccordionItem>
                     </Accordion>,
                 );

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
 import { AccordionContext, Consumer, Provider } from './AccordionContext';
 import { UUID } from './ItemContext';
 
-type AccordionWrapperProps = Pick<
+type AccordionProps = Pick<
     DivAttributes,
     Exclude<keyof DivAttributes, 'onChange'>
 > & {
@@ -13,14 +14,16 @@ type AccordionWrapperProps = Pick<
     onChange?(args: UUID[]): void;
 };
 
-export default class Accordion extends React.Component<AccordionWrapperProps> {
-    static defaultProps: AccordionWrapperProps = {
+export default class Accordion extends React.Component<AccordionProps> {
+    static defaultProps: AccordionProps = {
         allowMultipleExpanded: undefined,
         allowZeroExpanded: undefined,
         onChange: undefined,
         className: 'accordion',
         children: undefined,
     };
+
+    static displayName: DisplayName.Accordion = DisplayName.Accordion;
 
     renderAccordion = (accordionContext: AccordionContext): JSX.Element => {
         const {

--- a/src/components/AccordionContext.tsx
+++ b/src/components/AccordionContext.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import AccordionStore, {
+    InjectedButtonAttributes,
     InjectedHeadingAttributes,
     InjectedPanelAttributes,
 } from '../helpers/AccordionStore';
@@ -25,6 +26,7 @@ export interface AccordionContext {
     isItemExpanded(uuid: UUID): boolean;
     getPanelAttributes(uuid: UUID): InjectedPanelAttributes;
     getHeadingAttributes(uuid: UUID): InjectedHeadingAttributes;
+    getButtonAttributes(uuid: UUID): InjectedButtonAttributes;
 }
 
 const Context = React.createContext(null as AccordionContext | null);
@@ -71,6 +73,10 @@ export class Provider extends React.PureComponent<
         return this.state.getHeadingAttributes(key);
     };
 
+    getButtonAttributes = (key: UUID): InjectedButtonAttributes => {
+        return this.state.getButtonAttributes(key);
+    };
+
     render(): JSX.Element {
         const { allowZeroExpanded, allowMultipleExpanded } = this.state;
 
@@ -84,6 +90,7 @@ export class Provider extends React.PureComponent<
                     isItemExpanded: this.isItemExpanded,
                     getPanelAttributes: this.getPanelAttributes,
                     getHeadingAttributes: this.getHeadingAttributes,
+                    getButtonAttributes: this.getButtonAttributes,
                 }}
             >
                 {this.props.children || null}

--- a/src/components/AccordionItem.spec.tsx
+++ b/src/components/AccordionItem.spec.tsx
@@ -5,7 +5,7 @@ import AccordionItem from './AccordionItem';
 
 enum UUIDS {
     FOO = 'FOO',
-    BAR = 'Bar',
+    BAR = 'BAR',
 }
 
 describe('AccordionItem', () => {
@@ -19,19 +19,14 @@ describe('AccordionItem', () => {
         }).not.toThrow();
     });
 
-    describe('className + expandedClassName', () => {
-        it('are “BEM” by default', () => {
+    describe('className prop', () => {
+        it('is “BEM” by default', () => {
             const { getByTestId } = render(
-                <Accordion preExpanded={[UUIDS.FOO]}>
+                <Accordion>
                     <AccordionItem uuid={UUIDS.FOO} data-testid={UUIDS.FOO} />
-                    <AccordionItem uuid={UUIDS.BAR} data-testid={UUIDS.BAR} />
                 </Accordion>,
             );
             expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
-                'accordion__item',
-                'accordion__item--expanded',
-            ]);
-            expect(Array.from(getByTestId(UUIDS.BAR).classList)).toEqual([
                 'accordion__item',
             ]);
         });
@@ -43,22 +38,11 @@ describe('AccordionItem', () => {
                         uuid={UUIDS.FOO}
                         data-testid={UUIDS.FOO}
                         className="foo"
-                        expandedClassName="foo--expanded"
-                    />
-                    <AccordionItem
-                        uuid={UUIDS.BAR}
-                        data-testid={UUIDS.BAR}
-                        className="foo"
-                        expandedClassName="foo--expanded"
                     />
                 </Accordion>,
             );
 
             expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
-                'foo',
-                'foo--expanded',
-            ]);
-            expect(Array.from(getByTestId(UUIDS.BAR).classList)).toEqual([
                 'foo',
             ]);
         });

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -1,49 +1,18 @@
-import { default as classnames } from 'classnames';
 import * as React from 'react';
 import { DivAttributes } from '../helpers/types';
 import { nextUuid } from '../helpers/uuid';
-import {
-    Consumer as ItemConsumer,
-    ItemContext,
-    Provider as ItemProvider,
-    UUID,
-} from './ItemContext';
+import { Provider as ItemProvider, UUID } from './ItemContext';
 
-type Props = Pick<DivAttributes, Exclude<keyof DivAttributes, 'role'>> & {
-    expanded: boolean;
-    className?: string;
-    expandedClassName?: string;
+type Props = DivAttributes & {
+    uuid?: UUID;
 };
 
 const defaultProps = {
     className: 'accordion__item',
-    expandedClassName: 'accordion__item--expanded',
 };
 
-class AccordionItem extends React.Component<Props> {
+export default class AccordionItem extends React.Component<Props> {
     static defaultProps: typeof defaultProps = defaultProps;
-
-    render(): JSX.Element {
-        const { className, expanded, expandedClassName, ...rest } = this.props;
-
-        return (
-            <div
-                className={classnames(className, {
-                    [String(expandedClassName)]: expanded && expandedClassName,
-                })}
-                {...rest}
-            />
-        );
-    }
-}
-
-type WrapperProps = Pick<Props, Exclude<keyof Props, 'expanded'>> & {
-    uuid?: UUID;
-};
-
-export default class AccordionItemWrapper extends React.Component<
-    WrapperProps
-> {
     instanceUuid: UUID = nextUuid();
 
     render(): JSX.Element {
@@ -51,13 +20,7 @@ export default class AccordionItemWrapper extends React.Component<
 
         return (
             <ItemProvider uuid={uuid}>
-                <ItemConsumer>
-                    {(itemContext: ItemContext): JSX.Element => {
-                        const { expanded } = itemContext;
-
-                        return <AccordionItem {...rest} expanded={expanded} />;
-                    }}
-                </ItemConsumer>
+                <div {...rest} />
             </ItemProvider>
         );
     }

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
 import { nextUuid } from '../helpers/uuid';
 import { Provider as ItemProvider, UUID } from './ItemContext';
@@ -13,6 +14,9 @@ const defaultProps = {
 
 export default class AccordionItem extends React.Component<Props> {
     static defaultProps: typeof defaultProps = defaultProps;
+
+    static displayName: DisplayName.AccordionItem = DisplayName.AccordionItem;
+
     instanceUuid: UUID = nextUuid();
 
     render(): JSX.Element {

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -20,7 +20,7 @@ export default class AccordionItem extends React.Component<Props> {
 
         return (
             <ItemProvider uuid={uuid}>
-                <div {...rest} />
+                <div data-accordion-component="AccordionItem" {...rest} />
             </ItemProvider>
         );
     }

--- a/src/components/AccordionItemButton.spec.tsx
+++ b/src/components/AccordionItemButton.spec.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { cleanup, render } from 'react-testing-library';
+import Accordion from './Accordion';
+import AccordionItem from './AccordionItem';
+import AccordionItemButton from './AccordionItemButton';
+import AccordionItemHeading from './AccordionItemHeading';
+
+enum UUIDS {
+    FOO = 'FOO',
+    BAR = 'BAR',
+}
+
+describe('AccordionItem', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders without erroring', () => {
+        expect(() => {
+            render(<Accordion />);
+        }).not.toThrow();
+    });
+
+    describe('className prop', () => {
+        it('is “BEM” by default', () => {
+            const { getByTestId } = render(
+                <Accordion>
+                    <AccordionItem uuid={UUIDS.FOO}>
+                        <AccordionItemHeading>
+                            <AccordionItemButton data-testid={UUIDS.FOO} />
+                        </AccordionItemHeading>
+                    </AccordionItem>
+                </Accordion>,
+            );
+
+            expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
+                'accordion__button',
+            ]);
+        });
+
+        it('can be overridden', () => {
+            const { getByTestId } = render(
+                <Accordion>
+                    <AccordionItem uuid={UUIDS.FOO}>
+                        <AccordionItemHeading>
+                            <AccordionItemButton
+                                data-testid={UUIDS.FOO}
+                                className="foo"
+                            />
+                        </AccordionItemHeading>
+                    </AccordionItem>
+                </Accordion>,
+            );
+
+            expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
+                'foo',
+            ]);
+        });
+    });
+
+    describe('children prop', () => {
+        it('is respected', () => {
+            const { getByText } = render(
+                <Accordion>
+                    <AccordionItem>
+                        <AccordionItemHeading>
+                            <AccordionItemButton>
+                                Hello World
+                            </AccordionItemButton>
+                        </AccordionItemHeading>
+                    </AccordionItem>
+                </Accordion>,
+            );
+            expect(getByText('Hello World')).toBeTruthy();
+        });
+    });
+});

--- a/src/components/AccordionItemButton.tsx
+++ b/src/components/AccordionItemButton.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { InjectedButtonAttributes } from '../helpers/AccordionStore';
+import {
+    focusFirstSiblingOf,
+    focusLastSiblingOf,
+    focusNextSiblingOf,
+    focusPreviousSiblingOf,
+} from '../helpers/focus';
+import keycodes from '../helpers/keycodes';
+import { DivAttributes } from '../helpers/types';
+
+import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+
+type Props = DivAttributes & {
+    toggleExpanded(): void;
+};
+
+const defaultProps = {
+    className: 'accordion__button',
+};
+
+export class AccordionItemButton extends React.PureComponent<Props> {
+    static defaultProps: typeof defaultProps = defaultProps;
+
+    handleKeyPress = (evt: React.KeyboardEvent<HTMLDivElement>): void => {
+        const keyCode = evt.which.toString();
+
+        if (keyCode === keycodes.ENTER || keyCode === keycodes.SPACE) {
+            evt.preventDefault();
+            this.props.toggleExpanded();
+        }
+
+        /* The following block is ignored from test coverage because at time
+         * time of writing Jest/react-testing-library can not assert 'focus'
+         * functionality.
+         */
+        // istanbul ignore next
+        if (evt.target instanceof HTMLElement) {
+            switch (keyCode) {
+                case keycodes.HOME: {
+                    evt.preventDefault();
+                    focusFirstSiblingOf(evt.target);
+                    break;
+                }
+                case keycodes.END: {
+                    evt.preventDefault();
+                    focusLastSiblingOf(evt.target);
+                    break;
+                }
+                case keycodes.LEFT:
+                case keycodes.UP: {
+                    evt.preventDefault();
+                    focusPreviousSiblingOf(evt.target);
+                    break;
+                }
+                case keycodes.RIGHT:
+                case keycodes.DOWN: {
+                    evt.preventDefault();
+                    focusNextSiblingOf(evt.target);
+                    break;
+                }
+                default: {
+                    //
+                }
+            }
+        }
+    };
+
+    render(): JSX.Element {
+        const { toggleExpanded, ...rest } = this.props;
+
+        return (
+            <div
+                {...rest}
+                // tslint:disable-next-line react-a11y-event-has-role
+                onClick={toggleExpanded}
+                onKeyDown={this.handleKeyPress}
+                data-accordion-component="AccordionItemButton"
+            />
+        );
+    }
+}
+
+type WrapperProps = Pick<
+    DivAttributes,
+    Exclude<keyof DivAttributes, keyof InjectedButtonAttributes>
+>;
+
+const Wrapper: React.SFC<WrapperProps> = (props: WrapperProps): JSX.Element => (
+    <ItemConsumer>
+        {(itemContext: ItemContext): JSX.Element => {
+            const { toggleExpanded, buttonAttributes } = itemContext;
+
+            return (
+                <AccordionItemButton
+                    toggleExpanded={toggleExpanded}
+                    {...props}
+                    {...buttonAttributes}
+                />
+            );
+        }}
+    </ItemConsumer>
+);
+
+export default Wrapper;

--- a/src/components/AccordionItemButton.tsx
+++ b/src/components/AccordionItemButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { InjectedButtonAttributes } from '../helpers/AccordionStore';
+import DisplayName from '../helpers/DisplayName';
 import {
     focusFirstSiblingOf,
     focusLastSiblingOf,
@@ -86,7 +87,9 @@ type WrapperProps = Pick<
     Exclude<keyof DivAttributes, keyof InjectedButtonAttributes>
 >;
 
-const Wrapper: React.SFC<WrapperProps> = (props: WrapperProps): JSX.Element => (
+const AccordionItemButtonWrapper: React.SFC<WrapperProps> = (
+    props: WrapperProps,
+): JSX.Element => (
     <ItemConsumer>
         {(itemContext: ItemContext): JSX.Element => {
             const { toggleExpanded, buttonAttributes } = itemContext;
@@ -102,4 +105,6 @@ const Wrapper: React.SFC<WrapperProps> = (props: WrapperProps): JSX.Element => (
     </ItemConsumer>
 );
 
-export default Wrapper;
+AccordionItemButtonWrapper.displayName = DisplayName.AccordionItemButton;
+
+export default AccordionItemButtonWrapper;

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -20,7 +20,7 @@ describe('AccordionItem', () => {
         }).not.toThrow();
     });
 
-    describe('className prop', () => {
+    describe('headingClassName prop', () => {
         it('are “BEM” by default', () => {
             const { getByTestId } = render(
                 <Accordion>
@@ -41,7 +41,7 @@ describe('AccordionItem', () => {
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemHeading
                             data-testid={UUIDS.FOO}
-                            className="foo"
+                            headingClassName="foo"
                         />
                     </AccordionItem>
                 </Accordion>,

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -20,53 +20,34 @@ describe('AccordionItem', () => {
         }).not.toThrow();
     });
 
-    describe('className + expandedClassName', () => {
+    describe('className prop', () => {
         it('are “BEM” by default', () => {
             const { getByTestId } = render(
-                <Accordion preExpanded={[UUIDS.FOO]}>
+                <Accordion>
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemHeading data-testid={UUIDS.FOO} />
-                    </AccordionItem>
-                    <AccordionItem uuid={UUIDS.BAR}>
-                        <AccordionItemHeading data-testid={UUIDS.BAR} />
                     </AccordionItem>
                 </Accordion>,
             );
 
             expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
-                'accordion__heading',
-                'accordion__heading--expanded',
-            ]);
-            expect(Array.from(getByTestId(UUIDS.BAR).classList)).toEqual([
                 'accordion__heading',
             ]);
         });
 
         it('can be overridden', () => {
             const { getByTestId } = render(
-                <Accordion preExpanded={[UUIDS.FOO]}>
+                <Accordion>
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemHeading
                             data-testid={UUIDS.FOO}
                             className="foo"
-                            expandedClassName="foo--expanded"
-                        />
-                    </AccordionItem>
-                    <AccordionItem uuid={UUIDS.BAR}>
-                        <AccordionItemHeading
-                            data-testid={UUIDS.BAR}
-                            className="foo"
-                            expandedClassName="foo--expanded"
                         />
                     </AccordionItem>
                 </Accordion>,
             );
 
             expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
-                'foo',
-                'foo--expanded',
-            ]);
-            expect(Array.from(getByTestId(UUIDS.BAR).classList)).toEqual([
                 'foo',
             ]);
         });

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -76,6 +76,19 @@ describe('AccordionItem', () => {
     });
 
     describe('validation', () => {
+        // tslint:disable-next-line no-console
+        const originalError = console.error;
+
+        beforeEach(() => {
+            // tslint:disable-next-line no-console
+            console.error = jest.fn();
+        });
+
+        afterAll(() => {
+            // tslint:disable-next-line no-console
+            console.error = originalError;
+        });
+
         it('permits a single AccordionItemButton as a child - variation #1', () => {
             expect(() =>
                 render(

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { cleanup, render } from 'react-testing-library';
 import Accordion from './Accordion';
 import AccordionItem from './AccordionItem';
-import AccordionItemHeading from './AccordionItemHeading';
+import AccordionItemButton from './AccordionItemButton';
+import AccordionItemHeading, { SPEC_ERROR } from './AccordionItemHeading';
 
 enum UUIDS {
     FOO = 'FOO',
@@ -25,7 +26,9 @@ describe('AccordionItem', () => {
             const { getByTestId } = render(
                 <Accordion>
                     <AccordionItem uuid={UUIDS.FOO}>
-                        <AccordionItemHeading data-testid={UUIDS.FOO} />
+                        <AccordionItemHeading data-testid={UUIDS.FOO}>
+                            <AccordionItemButton />
+                        </AccordionItemHeading>
                     </AccordionItem>
                 </Accordion>,
             );
@@ -42,7 +45,9 @@ describe('AccordionItem', () => {
                         <AccordionItemHeading
                             data-testid={UUIDS.FOO}
                             className="foo"
-                        />
+                        >
+                            <AccordionItemButton />
+                        </AccordionItemHeading>
                     </AccordionItem>
                 </Accordion>,
             );
@@ -58,11 +63,75 @@ describe('AccordionItem', () => {
             const { getByText } = render(
                 <Accordion>
                     <AccordionItem>
-                        <AccordionItemHeading>Hello World</AccordionItemHeading>
+                        <AccordionItemHeading>
+                            <AccordionItemButton>
+                                Hello World
+                            </AccordionItemButton>
+                        </AccordionItemHeading>
                     </AccordionItem>
                 </Accordion>,
             );
             expect(getByText('Hello World')).toBeTruthy();
+        });
+    });
+
+    describe('validation', () => {
+        it('permits a single AccordionItemButton as a child - variation #1', () => {
+            expect(() =>
+                render(
+                    <Accordion>
+                        <AccordionItem>
+                            <AccordionItemHeading>
+                                <AccordionItemButton>
+                                    Hello World
+                                </AccordionItemButton>
+                            </AccordionItemHeading>
+                        </AccordionItem>
+                    </Accordion>,
+                ),
+            ).not.toThrowError(SPEC_ERROR);
+        });
+
+        it('permits a single AccordionItemButton as a child - variation #2', () => {
+            expect(() =>
+                render(
+                    <Accordion>
+                        <AccordionItem>
+                            <AccordionItemHeading>
+                                [
+                                <AccordionItemButton key="foo">
+                                    Hello World
+                                </AccordionItemButton>
+                                ]
+                            </AccordionItemHeading>
+                        </AccordionItem>
+                    </Accordion>,
+                ),
+            ).not.toThrowError(SPEC_ERROR);
+        });
+
+        it('throws an error if you don’t nest an AccordionItemButton', () => {
+            expect(() =>
+                render(
+                    <Accordion>
+                        <AccordionItem>
+                            <AccordionItemHeading />
+                        </AccordionItem>
+                    </Accordion>,
+                ),
+            ).toThrowError(SPEC_ERROR);
+        });
+
+        it('throws an error if you nest any non-AccordionItemButton element', () => {
+            expect(() =>
+                render(
+                    <Accordion>
+                        <AccordionItem>
+                            <AccordionItemHeading>Foo</AccordionItemHeading>
+                        </AccordionItem>
+                    </Accordion>,
+                ),
+            ).toThrowError(SPEC_ERROR);
         });
     });
 });

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -6,7 +6,7 @@ import AccordionItemHeading from './AccordionItemHeading';
 
 enum UUIDS {
     FOO = 'FOO',
-    BAR = 'Bar',
+    BAR = 'BAR',
 }
 
 describe('AccordionItem', () => {
@@ -20,8 +20,8 @@ describe('AccordionItem', () => {
         }).not.toThrow();
     });
 
-    describe('headingClassName prop', () => {
-        it('are “BEM” by default', () => {
+    describe('className prop', () => {
+        it('is “BEM” by default', () => {
             const { getByTestId } = render(
                 <Accordion>
                     <AccordionItem uuid={UUIDS.FOO}>
@@ -41,7 +41,7 @@ describe('AccordionItem', () => {
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemHeading
                             data-testid={UUIDS.FOO}
-                            headingClassName="foo"
+                            className="foo"
                         />
                     </AccordionItem>
                 </Accordion>,

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -12,14 +12,54 @@ const defaultProps = {
     'aria-level': 3,
 };
 
+export const SPEC_ERROR = `AccordionItemButton may contain only one child element, which must be an instance of AccordionItemButton.
+
+From the WAI-ARIA spec (https://www.w3.org/TR/wai-aria-practices-1.1/#accordion):
+
+“The button element is the only element inside the heading element. That is, if there are other visually persistent elements, they are not included inside the heading element.”
+
+`;
+
 export class AccordionItemHeading extends React.PureComponent<Props> {
     static defaultProps: typeof defaultProps = defaultProps;
+
+    ref: HTMLDivElement | undefined;
+
+    static VALIDATE(ref: HTMLDivElement | undefined): void | never {
+        if (ref === undefined) {
+            throw new Error('ref is undefined');
+        }
+        if (
+            !(
+                ref.childElementCount === 1 &&
+                ref.firstElementChild &&
+                ref.firstElementChild.getAttribute(
+                    'data-accordion-component',
+                ) === 'AccordionItemButton'
+            )
+        ) {
+            throw new Error(SPEC_ERROR);
+        }
+    }
+
+    setRef = (ref: HTMLDivElement): void => {
+        this.ref = ref;
+    };
+
+    componentDidUpdate(): void {
+        AccordionItemHeading.VALIDATE(this.ref);
+    }
+
+    componentDidMount(): void {
+        AccordionItemHeading.VALIDATE(this.ref);
+    }
 
     render(): JSX.Element {
         return (
             <div
                 data-accordion-component="AccordionItemHeading"
                 {...this.props}
+                ref={this.setRef}
             />
         );
     }

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -1,4 +1,3 @@
-import { default as classnames } from 'classnames';
 import * as React from 'react';
 import {
     focusFirstSiblingOf,
@@ -12,14 +11,11 @@ import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
 type Props = Pick<DivAttributes, Exclude<keyof DivAttributes, 'role'>> & {
-    expandedClassName?: string;
-    expanded: boolean;
     toggleExpanded(): void;
 };
 
 const defaultProps = {
     className: 'accordion__heading',
-    expandedClassName: 'accordion__heading--expanded',
 };
 
 export class AccordionItemHeading extends React.PureComponent<Props> {
@@ -70,22 +66,11 @@ export class AccordionItemHeading extends React.PureComponent<Props> {
     };
 
     render(): JSX.Element {
-        const {
-            className,
-            expandedClassName,
-            expanded,
-            toggleExpanded,
-            ...rest
-        } = this.props;
-
-        const headingClassName = classnames(className, {
-            [String(expandedClassName)]: expandedClassName && expanded,
-        });
+        const { toggleExpanded, ...rest } = this.props;
 
         return (
             <div
                 // tslint:disable-next-line react-a11y-event-has-role
-                className={headingClassName}
                 onClick={toggleExpanded}
                 data-accordion-component="AccordionItemHeading"
                 onKeyDown={this.handleKeyPress}
@@ -95,20 +80,16 @@ export class AccordionItemHeading extends React.PureComponent<Props> {
     }
 }
 
-type WrapperProps = Pick<
-    Props,
-    Exclude<keyof Props, 'toggleExpanded' | 'expanded'>
->;
+type WrapperProps = Pick<Props, Exclude<keyof Props, 'toggleExpanded'>>;
 
 const Wrapper: React.SFC<WrapperProps> = (props: WrapperProps): JSX.Element => (
     <ItemConsumer>
         {(itemContext: ItemContext): JSX.Element => {
-            const { expanded, toggleExpanded, headingAttributes } = itemContext;
+            const { toggleExpanded, headingAttributes } = itemContext;
 
             return (
                 <AccordionItemHeading
                     {...props}
-                    expanded={expanded}
                     toggleExpanded={toggleExpanded}
                     {...headingAttributes}
                 />

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -1,145 +1,42 @@
 import * as React from 'react';
-import {
-    InjectedButtonAttributes,
-    InjectedHeadingAttributes,
-} from '../helpers/AccordionStore';
-import {
-    focusFirstSiblingOf,
-    focusLastSiblingOf,
-    focusNextSiblingOf,
-    focusPreviousSiblingOf,
-} from '../helpers/focus';
-import keycodes from '../helpers/keycodes';
+import { InjectedHeadingAttributes } from '../helpers/AccordionStore';
+import { DivAttributes } from '../helpers/types';
 
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
-type Props = {
-    children?: React.ReactNode;
-    'aria-level'?: number;
-    headingAttributes: InjectedHeadingAttributes;
-    buttonAttributes: InjectedButtonAttributes;
-    headingClassName?: string;
-    buttonClassName?: string;
-    toggleExpanded(): void;
-};
+type Props = DivAttributes;
 
 const defaultProps = {
-    headingClassName: 'accordion__heading',
-    buttonClassName: 'accordion__button',
+    className: 'accordion__heading',
     'aria-level': 3,
 };
 
 export class AccordionItemHeading extends React.PureComponent<Props> {
     static defaultProps: typeof defaultProps = defaultProps;
 
-    handleKeyPress = (evt: React.KeyboardEvent<HTMLDivElement>): void => {
-        const keyCode = evt.which.toString();
-
-        if (keyCode === keycodes.ENTER || keyCode === keycodes.SPACE) {
-            evt.preventDefault();
-            this.props.toggleExpanded();
-        }
-
-        /* The following block is ignored from test coverage because at time
-         * time of writing Jest/react-testing-library can not assert 'focus'
-         * functionality.
-         */
-        // istanbul ignore next
-        if (evt.target instanceof HTMLElement) {
-            switch (keyCode) {
-                case keycodes.HOME: {
-                    evt.preventDefault();
-                    focusFirstSiblingOf(evt.target);
-                    break;
-                }
-                case keycodes.END: {
-                    evt.preventDefault();
-                    focusLastSiblingOf(evt.target);
-                    break;
-                }
-                case keycodes.LEFT:
-                case keycodes.UP: {
-                    evt.preventDefault();
-                    focusPreviousSiblingOf(evt.target);
-                    break;
-                }
-                case keycodes.RIGHT:
-                case keycodes.DOWN: {
-                    evt.preventDefault();
-                    focusNextSiblingOf(evt.target);
-                    break;
-                }
-                default: {
-                    //
-                }
-            }
-        }
-    };
-
     render(): JSX.Element {
-        const {
-            toggleExpanded,
-            headingAttributes,
-            buttonAttributes,
-            headingClassName,
-            buttonClassName,
-            'aria-level': ariaLevel,
-            children,
-        } = this.props;
-
         return (
             <div
-                // tslint:disable-next-line react-a11y-role-supports-aria-props
-                className={headingClassName}
                 data-accordion-component="AccordionItemHeading"
-                aria-level={ariaLevel}
-                {...headingAttributes}
-            >
-                <div
-                    // tslint:disable-next-line react-a11y-event-has-role
-                    onClick={toggleExpanded}
-                    onKeyDown={this.handleKeyPress}
-                    className={buttonClassName}
-                    data-accordion-component="AccordionItemButton"
-                    {...buttonAttributes}
-                >
-                    {children}
-                </div>
-            </div>
+                {...this.props}
+            />
         );
     }
 }
 
-type WrapperProps = {
-    buttonClassName?: string;
-    headingClassName?: string;
-    children?: React.ReactNode;
-};
+type WrapperProps = Pick<
+    DivAttributes,
+    Exclude<keyof DivAttributes, keyof InjectedHeadingAttributes>
+>;
 
-const Wrapper: React.SFC<WrapperProps> = ({
-    headingClassName,
-    buttonClassName,
-    children,
-}: WrapperProps): JSX.Element => (
+const Wrapper: React.SFC<DivAttributes> = (
+    props: WrapperProps,
+): JSX.Element => (
     <ItemConsumer>
         {(itemContext: ItemContext): JSX.Element => {
-            const {
-                toggleExpanded,
-                headingAttributes,
-                buttonAttributes,
-            } = itemContext;
+            const { headingAttributes } = itemContext;
 
-            return (
-                <AccordionItemHeading
-                    toggleExpanded={toggleExpanded}
-                    headingClassName={headingClassName}
-                    buttonClassName={buttonClassName}
-                    headingAttributes={headingAttributes}
-                    buttonAttributes={buttonAttributes}
-                >
-                    {children}
-                </AccordionItemHeading>
-            );
+            return <AccordionItemHeading {...props} {...headingAttributes} />;
         }}
     </ItemConsumer>
 );

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { InjectedHeadingAttributes } from '../helpers/AccordionStore';
+import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
 
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
@@ -29,7 +30,7 @@ type WrapperProps = Pick<
     Exclude<keyof DivAttributes, keyof InjectedHeadingAttributes>
 >;
 
-const Wrapper: React.SFC<DivAttributes> = (
+const AccordionItemHeadingWrapper: React.SFC<DivAttributes> = (
     props: WrapperProps,
 ): JSX.Element => (
     <ItemConsumer>
@@ -41,4 +42,6 @@ const Wrapper: React.SFC<DivAttributes> = (
     </ItemConsumer>
 );
 
-export default Wrapper;
+AccordionItemHeadingWrapper.displayName = DisplayName.AccordionItemHeading;
+
+export default AccordionItemHeadingWrapper;

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
 import {
+    InjectedButtonAttributes,
+    InjectedHeadingAttributes,
+} from '../helpers/AccordionStore';
+import {
     focusFirstSiblingOf,
     focusLastSiblingOf,
     focusNextSiblingOf,
@@ -7,15 +11,20 @@ import {
 } from '../helpers/focus';
 import keycodes from '../helpers/keycodes';
 
-import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
-type Props = Pick<DivAttributes, Exclude<keyof DivAttributes, 'role'>> & {
+type Props = {
+    children?: React.ReactNode;
+    headingAttributes: InjectedHeadingAttributes;
+    buttonAttributes: InjectedButtonAttributes;
+    headingClassName?: string;
+    buttonClassName?: string;
     toggleExpanded(): void;
 };
 
 const defaultProps = {
-    className: 'accordion__heading',
+    headingClassName: 'accordion__heading',
+    buttonClassName: 'accordion__button',
 };
 
 export class AccordionItemHeading extends React.PureComponent<Props> {
@@ -66,33 +75,65 @@ export class AccordionItemHeading extends React.PureComponent<Props> {
     };
 
     render(): JSX.Element {
-        const { toggleExpanded, ...rest } = this.props;
+        const {
+            toggleExpanded,
+            headingAttributes,
+            buttonAttributes,
+            headingClassName,
+            buttonClassName,
+            children,
+        } = this.props;
 
         return (
             <div
-                // tslint:disable-next-line react-a11y-event-has-role
-                onClick={toggleExpanded}
+                className={headingClassName}
                 data-accordion-component="AccordionItemHeading"
-                onKeyDown={this.handleKeyPress}
-                {...rest}
-            />
+                {...headingAttributes}
+            >
+                <div
+                    // tslint:disable-next-line react-a11y-event-has-role
+                    onClick={toggleExpanded}
+                    onKeyDown={this.handleKeyPress}
+                    className={buttonClassName}
+                    data-accordion-component="AccordionItemButton"
+                    {...buttonAttributes}
+                >
+                    {children}
+                </div>
+            </div>
         );
     }
 }
 
-type WrapperProps = Pick<Props, Exclude<keyof Props, 'toggleExpanded'>>;
+type WrapperProps = {
+    buttonClassName?: string;
+    headingClassName?: string;
+    children?: React.ReactNode;
+};
 
-const Wrapper: React.SFC<WrapperProps> = (props: WrapperProps): JSX.Element => (
+const Wrapper: React.SFC<WrapperProps> = ({
+    headingClassName,
+    buttonClassName,
+    children,
+}: WrapperProps): JSX.Element => (
     <ItemConsumer>
         {(itemContext: ItemContext): JSX.Element => {
-            const { toggleExpanded, headingAttributes } = itemContext;
+            const {
+                toggleExpanded,
+                headingAttributes,
+                buttonAttributes,
+            } = itemContext;
 
             return (
                 <AccordionItemHeading
-                    {...props}
                     toggleExpanded={toggleExpanded}
-                    {...headingAttributes}
-                />
+                    headingClassName={headingClassName}
+                    buttonClassName={buttonClassName}
+                    headingAttributes={headingAttributes}
+                    buttonAttributes={buttonAttributes}
+                >
+                    {children}
+                </AccordionItemHeading>
             );
         }}
     </ItemConsumer>

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -15,6 +15,7 @@ import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
 type Props = {
     children?: React.ReactNode;
+    'aria-level'?: number;
     headingAttributes: InjectedHeadingAttributes;
     buttonAttributes: InjectedButtonAttributes;
     headingClassName?: string;
@@ -25,6 +26,7 @@ type Props = {
 const defaultProps = {
     headingClassName: 'accordion__heading',
     buttonClassName: 'accordion__button',
+    'aria-level': 3,
 };
 
 export class AccordionItemHeading extends React.PureComponent<Props> {
@@ -81,13 +83,16 @@ export class AccordionItemHeading extends React.PureComponent<Props> {
             buttonAttributes,
             headingClassName,
             buttonClassName,
+            'aria-level': ariaLevel,
             children,
         } = this.props;
 
         return (
             <div
+                // tslint:disable-next-line react-a11y-role-supports-aria-props
                 className={headingClassName}
                 data-accordion-component="AccordionItemHeading"
+                aria-level={ariaLevel}
                 {...headingAttributes}
             >
                 <div

--- a/src/components/AccordionItemPanel.spec.tsx
+++ b/src/components/AccordionItemPanel.spec.tsx
@@ -6,7 +6,7 @@ import AccordionItemPanel from './AccordionItemPanel';
 
 enum UUIDS {
     FOO = 'FOO',
-    BAR = 'Bar',
+    BAR = 'BAR',
 }
 
 describe('AccordionItem', () => {
@@ -20,53 +20,34 @@ describe('AccordionItem', () => {
         }).not.toThrow();
     });
 
-    describe('className + expandedClassName', () => {
-        it('are “BEM” by default', () => {
+    describe('className prop', () => {
+        it('is “BEM” by default', () => {
             const { getByTestId } = render(
-                <Accordion preExpanded={[UUIDS.FOO]}>
+                <Accordion>
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemPanel data-testid={UUIDS.FOO} />
-                    </AccordionItem>
-                    <AccordionItem uuid={UUIDS.BAR}>
-                        <AccordionItemPanel data-testid={UUIDS.BAR} />
                     </AccordionItem>
                 </Accordion>,
             );
 
             expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
-                'accordion__panel',
-                'accordion__panel--expanded',
-            ]);
-            expect(Array.from(getByTestId(UUIDS.BAR).classList)).toEqual([
                 'accordion__panel',
             ]);
         });
 
         it('can be overridden', () => {
             const { getByTestId } = render(
-                <Accordion preExpanded={[UUIDS.FOO]}>
+                <Accordion>
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemPanel
                             data-testid={UUIDS.FOO}
                             className="foo"
-                            expandedClassName="foo--expanded"
-                        />
-                    </AccordionItem>
-                    <AccordionItem uuid={UUIDS.BAR}>
-                        <AccordionItemPanel
-                            data-testid={UUIDS.BAR}
-                            className="foo"
-                            expandedClassName="foo--expanded"
                         />
                     </AccordionItem>
                 </Accordion>,
             );
 
             expect(Array.from(getByTestId(UUIDS.FOO).classList)).toEqual([
-                'foo',
-                'foo--expanded',
-            ]);
-            expect(Array.from(getByTestId(UUIDS.BAR).classList)).toEqual([
                 'foo',
             ]);
         });

--- a/src/components/AccordionItemPanel.tsx
+++ b/src/components/AccordionItemPanel.tsx
@@ -12,7 +12,13 @@ export default class AccordionItemPanel extends React.Component<Props> {
     static defaultProps: typeof defaultProps = defaultProps;
 
     renderChildren = ({ panelAttributes }: ItemContext): JSX.Element => {
-        return <div {...this.props} {...panelAttributes} />;
+        return (
+            <div
+                data-accordion-component="AccordionItemPanel"
+                {...this.props}
+                {...panelAttributes}
+            />
+        );
     };
 
     render(): JSX.Element {

--- a/src/components/AccordionItemPanel.tsx
+++ b/src/components/AccordionItemPanel.tsx
@@ -1,47 +1,18 @@
-import { default as classnames } from 'classnames';
 import * as React from 'react';
 import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
-type Props = DivAttributes & {
-    expandedClassName: string;
-    expanded: boolean;
+type Props = DivAttributes;
+
+const defaultProps = {
+    className: 'accordion__panel',
 };
 
-const AccordionItemPanel: React.SFC<Props> = ({
-    className,
-    expandedClassName,
-    expanded,
-    ...rest
-}: Props): JSX.Element => {
-    return (
-        <div
-            className={classnames(className, {
-                [expandedClassName]: expanded,
-            })}
-            {...rest}
-        />
-    );
-};
+export default class AccordionItemPanel extends React.Component<Props> {
+    static defaultProps: typeof defaultProps = defaultProps;
 
-type WrapperProps = Pick<Props, Exclude<keyof Props, 'expanded'>>;
-
-export default class Wrapper extends React.Component<WrapperProps> {
-    static defaultProps: { className: string; expandedClassName: string } = {
-        className: 'accordion__panel',
-        expandedClassName: 'accordion__panel--expanded',
-    };
-
-    renderChildren = (itemContext: ItemContext): JSX.Element => {
-        const { panelAttributes, expanded } = itemContext;
-
-        return (
-            <AccordionItemPanel
-                {...this.props}
-                {...panelAttributes}
-                expanded={expanded}
-            />
-        );
+    renderChildren = ({ panelAttributes }: ItemContext): JSX.Element => {
+        return <div {...this.props} {...panelAttributes} />;
     };
 
     render(): JSX.Element {

--- a/src/components/AccordionItemPanel.tsx
+++ b/src/components/AccordionItemPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
@@ -10,6 +11,9 @@ const defaultProps = {
 
 export default class AccordionItemPanel extends React.Component<Props> {
     static defaultProps: typeof defaultProps = defaultProps;
+
+    static displayName: DisplayName.AccordionItemPanel =
+        DisplayName.AccordionItemPanel;
 
     renderChildren = ({ panelAttributes }: ItemContext): JSX.Element => {
         return (

--- a/src/components/ItemContext.tsx
+++ b/src/components/ItemContext.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import {
+    InjectedButtonAttributes,
     InjectedHeadingAttributes,
     InjectedPanelAttributes,
 } from '../helpers/AccordionStore';
@@ -29,6 +30,7 @@ export type ItemContext = {
     disabled: boolean;
     panelAttributes: InjectedPanelAttributes;
     headingAttributes: InjectedHeadingAttributes;
+    buttonAttributes: InjectedButtonAttributes;
     toggleExpanded(): void;
 };
 
@@ -46,6 +48,7 @@ class Provider extends React.Component<ProviderProps> {
         const disabled = accordionContext.isItemDisabled(uuid);
         const panelAttributes = accordionContext.getPanelAttributes(uuid);
         const headingAttributes = accordionContext.getHeadingAttributes(uuid);
+        const buttonAttributes = accordionContext.getButtonAttributes(uuid);
 
         return (
             <Context.Provider
@@ -56,6 +59,7 @@ class Provider extends React.Component<ProviderProps> {
                     toggleExpanded: this.toggleExpanded,
                     panelAttributes,
                     headingAttributes,
+                    buttonAttributes,
                 }}
                 children={this.props.children}
             />

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -47,11 +47,6 @@
     animation: fadein 0.35s ease-in;
 }
 
-.accordion__heading > *:last-child,
-.accordion__panel > *:last-child {
-    margin-bottom: 0;
-}
-
 /* -------------------------------------------------- */
 /* ---------------- Animation part ------------------ */
 /* -------------------------------------------------- */

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -12,7 +12,7 @@
     border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.accordion__heading {
+.accordion__button {
     background-color: #f4f4f4;
     color: #444;
     cursor: pointer;
@@ -22,7 +22,7 @@
     border: none;
 }
 
-.accordion__heading:hover {
+.accordion__button:hover {
     background-color: #ddd;
 }
 

--- a/src/css/fancy-example.css
+++ b/src/css/fancy-example.css
@@ -26,6 +26,22 @@
     background-color: #ddd;
 }
 
+.accordion__button:before {
+    display: inline-block;
+    content: '';
+    height: 10px;
+    width: 10px;
+    margin-right: 12px;
+    border-bottom: 2px solid currentColor;
+    border-right: 2px solid currentColor;
+    transform: rotate(-45deg);
+}
+
+.accordion__button[aria-expanded='true']::before,
+.accordion__button[aria-selected='true']::before {
+    transform: rotate(45deg);
+}
+
 .accordion__panel {
     padding: 20px;
     animation: fadein 0.35s ease-in;
@@ -34,50 +50,6 @@
 .accordion__heading > *:last-child,
 .accordion__panel > *:last-child {
     margin-bottom: 0;
-}
-
-.accordion__arrow {
-    display: inline-block;
-    position: relative;
-    width: 24px;
-    height: 12px;
-    margin-right: 12px;
-}
-
-.accordion__arrow::after,
-.accordion__arrow::before {
-    display: block;
-    position: absolute;
-    top: 50%;
-    width: 10px;
-    height: 2px;
-    background-color: currentColor;
-    content: '';
-}
-
-.accordion__arrow::before {
-    left: 4px;
-    transform: rotate(45deg);
-}
-
-[aria-expanded='true'] .accordion__arrow::before,
-[aria-selected='true'] .accordion__arrow::before {
-    transform: rotate(-45deg);
-}
-
-.accordion__arrow::after {
-    right: 4px;
-    transform: rotate(-45deg);
-}
-
-[aria-expanded='true'] .accordion__arrow::after,
-[aria-selected='true'] .accordion__arrow::after {
-    transform: rotate(45deg);
-}
-
-.accordion__arrow::before,
-.accordion__arrow::after {
-    transition: transform 0.25s ease, -webkit-transform 0.25s ease;
 }
 
 /* -------------------------------------------------- */

--- a/src/helpers/AccordionStore.ts
+++ b/src/helpers/AccordionStore.ts
@@ -5,10 +5,14 @@ export interface InjectedPanelAttributes {
     'aria-hidden': boolean | undefined;
     'aria-labelledby': string;
     id: string;
-    hidden: boolean | undefined; // Any string value is interpreted as 'true'.
+    hidden: boolean | undefined;
 }
 
 export interface InjectedHeadingAttributes {
+    role: string;
+}
+
+export interface InjectedButtonAttributes {
     id: string;
     'aria-controls': string;
     'aria-expanded': boolean;
@@ -89,7 +93,7 @@ export default class AccordionStore {
         return {
             role: this.allowMultipleExpanded ? undefined : 'region',
             'aria-hidden': this.allowMultipleExpanded ? !expanded : undefined,
-            'aria-labelledby': this.getHeadingId(uuid),
+            'aria-labelledby': this.getButtonId(uuid),
             id: this.getPanelId(uuid),
             hidden: expanded ? undefined : true,
         };
@@ -98,14 +102,22 @@ export default class AccordionStore {
     public readonly getHeadingAttributes = (
         uuid: UUID,
     ): InjectedHeadingAttributes => {
+        return {
+            role: 'heading',
+        };
+    };
+
+    public readonly getButtonAttributes = (
+        uuid: UUID,
+    ): InjectedButtonAttributes => {
         const expanded = this.isItemExpanded(uuid);
         const disabled = this.isItemDisabled(uuid);
 
         return {
-            id: this.getHeadingId(uuid),
-            'aria-controls': this.getPanelId(uuid),
-            'aria-expanded': expanded,
+            id: this.getButtonId(uuid),
             'aria-disabled': disabled,
+            'aria-expanded': expanded,
+            'aria-controls': this.getPanelId(uuid),
             role: 'button',
             tabIndex: 0,
         };
@@ -114,7 +126,7 @@ export default class AccordionStore {
     private readonly getPanelId = (uuid: UUID): string =>
         `accordion__panel-${uuid}`;
 
-    private readonly getHeadingId = (uuid: UUID): string =>
+    private readonly getButtonId = (uuid: UUID): string =>
         `accordion__heading-${uuid}`;
 
     private readonly augment = (args: {

--- a/src/helpers/DisplayName.ts
+++ b/src/helpers/DisplayName.ts
@@ -1,0 +1,9 @@
+enum DisplayName {
+    Accordion = 'Accordion',
+    AccordionItem = 'AccordionItem',
+    AccordionItemButton = 'AccordionItemButton',
+    AccordionItemHeading = 'AccordionItemHeading',
+    AccordionItemPanel = 'AccordionItemPanel',
+}
+
+export default DisplayName;

--- a/src/helpers/focus.spec.tsx
+++ b/src/helpers/focus.spec.tsx
@@ -4,7 +4,7 @@ import {
     focusNextSiblingOf,
     focusPreviousSiblingOf,
     getClosestAccordion,
-    getSiblingHeadings,
+    getSiblingButtons,
 } from './focus';
 
 describe('focus', () => {
@@ -86,224 +86,224 @@ describe('focus', () => {
         });
     });
 
-    describe('getSiblingHeadings', () => {
+    describe('getSiblingButtons', () => {
         it('returns adjacent siblings', () => {
             const tree = createTree(`
                 <div data-accordion-component="Accordion" id="parent">
-                    <div data-accordion-component="AccordionItemHeading">Heading</div>
-                    <div data-accordion-component="AccordionItemHeading">Heading</div>
-                    <div data-accordion-component="AccordionItemHeading">Heading</div>
+                    <div data-accordion-component="AccordionItemButton">Button</div>
+                    <div data-accordion-component="AccordionItemButton">Button</div>
+                    <div data-accordion-component="AccordionItemButton">Button</div>
                 </div>
             `);
 
-            const heading = tree.querySelector(
-                '[data-accordion-component="AccordionItemHeading"]',
+            const button = tree.querySelector(
+                '[data-accordion-component="AccordionItemButton"]',
             );
 
             // Predicate
-            if (!(heading instanceof HTMLElement)) {
-                throw new Error('heading not found');
+            if (!(button instanceof HTMLElement)) {
+                throw new Error('button not found');
             }
 
             // Matter
-            expect(getSiblingHeadings(heading)).toHaveLength(3);
+            expect(getSiblingButtons(button)).toHaveLength(3);
         });
 
         it('returns nested siblings', () => {
             const tree = createTree(`
                 <div data-accordion-component="Accordion" id="parent">
                     <div>
-                        <div data-accordion-component="AccordionItemHeading">Heading</div>
+                        <div data-accordion-component="AccordionItemButton">Button</div>
                     </div>
-                    <div data-accordion-component="AccordionItemHeading">Heading</div>
-                    <div data-accordion-component="AccordionItemHeading">Heading</div>
+                    <div data-accordion-component="AccordionItemButton">Button</div>
+                    <div data-accordion-component="AccordionItemButton">Button</div>
                 </div>
             `);
 
-            const heading = tree.querySelector(
-                '[data-accordion-component="AccordionItemHeading"]',
+            const button = tree.querySelector(
+                '[data-accordion-component="AccordionItemButton"]',
             );
 
             // Predicate
-            if (!(heading instanceof HTMLElement)) {
-                throw new Error('heading not found');
+            if (!(button instanceof HTMLElement)) {
+                throw new Error('button not found');
             }
 
             // Matter
-            expect(getSiblingHeadings(heading)).toHaveLength(3);
+            expect(getSiblingButtons(button)).toHaveLength(3);
         });
 
-        it('doesn‘t return headings "above" the accordion', () => {
+        it('doesn‘t return buttons "above" the accordion', () => {
             const tree = createTree(`
-                <div data-accordion-component="AccordionItemHeading">
+                <div data-accordion-component="AccordionItemButton">
                     <div data-accordion-component="Accordion" id="parent">
-                        <div data-accordion-component="AccordionItemHeading" id="first">Heading</div>
-                        <div data-accordion-component="AccordionItemHeading">Heading</div>
+                        <div data-accordion-component="AccordionItemButton" id="first">Button</div>
+                        <div data-accordion-component="AccordionItemButton">Button</div>
                     </div>
                 </div>
             `);
 
-            const heading = tree.querySelector('#first');
+            const button = tree.querySelector('#first');
 
             // Predicate
-            if (!(heading instanceof HTMLElement)) {
-                throw new Error('heading not found');
+            if (!(button instanceof HTMLElement)) {
+                throw new Error('button not found');
             }
 
             // Matter
-            expect(getSiblingHeadings(heading)).toHaveLength(2);
+            expect(getSiblingButtons(button)).toHaveLength(2);
         });
     });
 
     describe('focusFirstSiblingOf', () => {
-        it('focuses the first heading in document flow', () => {
+        it('focuses the first button in document flow', () => {
             const tree = createTree(`
                 <div data-accordion-component="Accordion">
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="1"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="2"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="3"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="1"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="2"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="3"></div>
                 </div>
             `);
 
-            const [firstHeading, secondHeading, thirdHeading] = Array.from(
+            const [firstButton, secondButton, thirdButton] = Array.from(
                 tree.querySelectorAll(
-                    '[data-accordion-component="AccordionItemHeading"]',
+                    '[data-accordion-component="AccordionItemButton"]',
                 ),
             );
 
             // Predicate
             if (
                 !(
-                    firstHeading instanceof HTMLElement &&
-                    secondHeading instanceof HTMLElement &&
-                    thirdHeading instanceof HTMLElement
+                    firstButton instanceof HTMLElement &&
+                    secondButton instanceof HTMLElement &&
+                    thirdButton instanceof HTMLElement
                 )
             ) {
-                throw new Error('headings not found');
+                throw new Error('buttons not found');
             }
-            thirdHeading.focus();
-            expect(document.activeElement).toBe(thirdHeading);
+            thirdButton.focus();
+            expect(document.activeElement).toBe(thirdButton);
 
             // Matter
-            focusFirstSiblingOf(thirdHeading);
-            expect(document.activeElement).toBe(firstHeading);
+            focusFirstSiblingOf(thirdButton);
+            expect(document.activeElement).toBe(firstButton);
         });
     });
 
     describe('focusLastSiblingOf', () => {
-        it('focuses the last heading in document flow', () => {
+        it('focuses the last button in document flow', () => {
             const tree = createTree(`
                 <div data-accordion-component="Accordion">
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="1"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="2"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="3"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="1"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="2"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="3"></div>
                 </div>
             `);
 
             const [
-                firstHeading,
-                secondHeading,
-                thirdHeading,
+                firstButton,
+                secondButton,
+                thirdButton,
             ]: HTMLElement[] = Array.from(
                 tree.querySelectorAll(
-                    '[data-accordion-component="AccordionItemHeading"]',
+                    '[data-accordion-component="AccordionItemButton"]',
                 ),
             );
 
             // Predicate
             if (
                 !(
-                    firstHeading instanceof HTMLElement &&
-                    secondHeading instanceof HTMLElement &&
-                    thirdHeading instanceof HTMLElement
+                    firstButton instanceof HTMLElement &&
+                    secondButton instanceof HTMLElement &&
+                    thirdButton instanceof HTMLElement
                 )
             ) {
-                throw new Error('headings not found');
+                throw new Error('buttons not found');
             }
-            firstHeading.focus();
-            expect(document.activeElement).toBe(firstHeading);
+            firstButton.focus();
+            expect(document.activeElement).toBe(firstButton);
 
             // Matter
-            focusLastSiblingOf(firstHeading);
-            expect(document.activeElement).toBe(thirdHeading);
+            focusLastSiblingOf(firstButton);
+            expect(document.activeElement).toBe(thirdButton);
         });
     });
 
     describe('focusNextSiblingOf', () => {
-        it('focuses the next heading in document flow', () => {
+        it('focuses the next button in document flow', () => {
             const tree = createTree(`
                 <div data-accordion-component="Accordion">
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="1"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="2"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="3"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="1"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="2"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="3"></div>
                 </div>
             `);
 
             const [
-                firstHeading,
-                secondHeading,
-                thirdHeading,
+                firstButton,
+                secondButton,
+                thirdButton,
             ]: HTMLElement[] = Array.from(
                 tree.querySelectorAll(
-                    '[data-accordion-component="AccordionItemHeading"]',
+                    '[data-accordion-component="AccordionItemButton"]',
                 ),
             );
 
             // Predicate
             if (
                 !(
-                    firstHeading instanceof HTMLElement &&
-                    secondHeading instanceof HTMLElement &&
-                    thirdHeading instanceof HTMLElement
+                    firstButton instanceof HTMLElement &&
+                    secondButton instanceof HTMLElement &&
+                    thirdButton instanceof HTMLElement
                 )
             ) {
-                throw new Error('headings not found');
+                throw new Error('buttons not found');
             }
-            firstHeading.focus();
-            expect(document.activeElement).toBe(firstHeading);
+            firstButton.focus();
+            expect(document.activeElement).toBe(firstButton);
 
             // Matter
-            focusNextSiblingOf(firstHeading);
-            expect(document.activeElement).toBe(secondHeading);
+            focusNextSiblingOf(firstButton);
+            expect(document.activeElement).toBe(secondButton);
         });
     });
 
     describe('focusPreviousSiblingOf', () => {
-        it('focuses the previous heading in document flow', () => {
+        it('focuses the previous button in document flow', () => {
             const tree = createTree(`
                 <div data-accordion-component="Accordion">
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="1"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="2"></div>
-                    <div data-accordion-component="AccordionItemHeading" tabindex="0" id="3"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="1"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="2"></div>
+                    <div data-accordion-component="AccordionItemButton" tabindex="0" id="3"></div>
                 </div>
             `);
 
             const [
-                firstHeading,
-                secondHeading,
-                thirdHeading,
+                firstButton,
+                secondButton,
+                thirdButton,
             ]: HTMLElement[] = Array.from(
                 tree.querySelectorAll(
-                    '[data-accordion-component="AccordionItemHeading"]',
+                    '[data-accordion-component="AccordionItemButton"]',
                 ),
             );
 
             // Predicate
             if (
                 !(
-                    firstHeading instanceof HTMLElement &&
-                    secondHeading instanceof HTMLElement &&
-                    thirdHeading instanceof HTMLElement
+                    firstButton instanceof HTMLElement &&
+                    secondButton instanceof HTMLElement &&
+                    thirdButton instanceof HTMLElement
                 )
             ) {
-                throw new Error('headings not found');
+                throw new Error('buttons not found');
             }
-            thirdHeading.focus();
-            expect(document.activeElement).toBe(thirdHeading);
+            thirdButton.focus();
+            expect(document.activeElement).toBe(thirdButton);
 
             // Matter
-            focusPreviousSiblingOf(thirdHeading);
-            expect(document.activeElement).toBe(secondHeading);
+            focusPreviousSiblingOf(thirdButton);
+            expect(document.activeElement).toBe(secondButton);
         });
     });
 });

--- a/src/helpers/focus.ts
+++ b/src/helpers/focus.ts
@@ -9,21 +9,21 @@ export function getClosestAccordion(
     );
 }
 
-export function getSiblingHeadings(item: HTMLElement): HTMLElement[] | null {
+export function getSiblingButtons(item: HTMLElement): HTMLElement[] | null {
     const parentAccordion = getClosestAccordion(item);
 
     return (
         parentAccordion &&
         Array.from(
             parentAccordion.querySelectorAll(
-                '[data-accordion-component="AccordionItemHeading"]',
+                '[data-accordion-component="AccordionItemButton"]',
             ),
         )
     );
 }
 
 export function focusFirstSiblingOf(item: HTMLElement): void {
-    const siblings = getSiblingHeadings(item) || [];
+    const siblings = getSiblingButtons(item) || [];
     const first = siblings[0];
     if (first) {
         first.focus();
@@ -31,7 +31,7 @@ export function focusFirstSiblingOf(item: HTMLElement): void {
 }
 
 export function focusLastSiblingOf(item: HTMLElement): void {
-    const siblings = getSiblingHeadings(item) || [];
+    const siblings = getSiblingButtons(item) || [];
     const last = siblings[siblings.length - 1];
     if (last) {
         last.focus();
@@ -39,7 +39,7 @@ export function focusLastSiblingOf(item: HTMLElement): void {
 }
 
 export function focusNextSiblingOf(item: HTMLElement): void {
-    const siblings = getSiblingHeadings(item) || [];
+    const siblings = getSiblingButtons(item) || [];
     const currentIndex = siblings.indexOf(item);
     if (currentIndex !== -1) {
         const next = siblings[currentIndex + 1];
@@ -50,7 +50,7 @@ export function focusNextSiblingOf(item: HTMLElement): void {
 }
 
 export function focusPreviousSiblingOf(item: HTMLElement): void {
-    const siblings = getSiblingHeadings(item) || [];
+    const siblings = getSiblingButtons(item) || [];
     const currentIndex = siblings.indexOf(item);
     if (currentIndex !== -1) {
         const previous = siblings[currentIndex - 1];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import Accordion from './components/Accordion';
 import AccordionItem from './components/AccordionItem';
+import AccordionItemButton from './components/AccordionItemButton';
 import AccordionItemHeading from './components/AccordionItemHeading';
 import AccordionItemPanel from './components/AccordionItemPanel';
 import AccordionItemState from './components/AccordionItemState';
@@ -8,6 +9,7 @@ import { resetNextUuid } from './helpers/uuid';
 export {
     Accordion,
     AccordionItem,
+    AccordionItemButton,
     AccordionItemHeading,
     AccordionItemPanel,
     AccordionItemState,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
         "integration/**/*.ts",
         "integration/**/*.tsx"
     ],
-    "exclude": ["demo/src/**/*"],
     "compilerOptions": {
         "noEmit": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
Splices the 'button' element out of `AccordionItemHeading` and into its own `AccordionItemButton` component.

A nice side-effect of this refactor was that the additional 'arrow' div was able to be refactored into a pseudo-element of the button, and as such the user no longer needs to add it explicitly.


