### PR TITLE
Chore/accordion item state object

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Class(es) to apply to element.
 
 ### AccordionItemState
 
-#### children : `(expanded: boolean): JSX.Element` [**required**]
+#### children : `({ expanded: boolean, disabled: boolean }): JSX.Element` [**required**]
 
 ---
 

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -10,6 +10,7 @@ import {
     AccordionItemButton,
     AccordionItemHeading,
     AccordionItemPanel,
+    AccordionItemState,
 } from '../../src';
 
 // tslint:disable-next-line no-import-side-effect
@@ -161,37 +162,36 @@ const App = (): JSX.Element => (
             ))}
         </Accordion>
 
-        <h2 className="u-margin-top" />
+        <h2 className="u-margin-top">Accessing Item State</h2>
+
+        <p>
+            If you'd like to apply different content or styling based on the{' '}
+            <strong>expanded</strong> or <strong>disabled</strong> state of an
+            item, you might like to use the <strong>AccordionItemState</strong>{' '}
+            render-prop component.
+        </p>
 
         <Accordion>
-            <AccordionItem>
-                <AccordionItemHeading>
-                    <AccordionItemButton>
-                        Render something different when expanded
-                    </AccordionItemButton>
-                </AccordionItemHeading>
-                <AccordionItemPanel>
-                    <p>
-                        When you open/close this item, you should see the text
-                        under the heading change.
-                    </p>
-                </AccordionItemPanel>
-            </AccordionItem>
-            <AccordionItem>
-                <AccordionItemHeading>
-                    <AccordionItemButton>How to?</AccordionItemButton>
-                </AccordionItemHeading>
-                <AccordionItemPanel>
-                    <p>
-                        Pass the AccordionItemState component a render prop
-                        function.
-                    </p>
-                    <p>
-                        This should take the item's expanded state as an
-                        argument.
-                    </p>
-                </AccordionItemPanel>
-            </AccordionItem>
+            {placeholders.map((placeholder: Placeholder) => (
+                <AccordionItem
+                    key={placeholder.heading}
+                    uuid={placeholder.uuid}
+                >
+                    <AccordionItemHeading>
+                        <AccordionItemButton>
+                            {placeholder.heading}
+                            <br />
+                            <br />
+                            <AccordionItemState>
+                                {(state: object): React.ReactNode =>
+                                    `State: ${JSON.stringify(state)}`
+                                }
+                            </AccordionItemState>
+                        </AccordionItemButton>
+                    </AccordionItemHeading>
+                    <AccordionItemPanel>{placeholder.panel}</AccordionItemPanel>
+                </AccordionItem>
+            ))}
         </Accordion>
     </div>
 );

--- a/src/components/AccordionItemState.spec.tsx
+++ b/src/components/AccordionItemState.spec.tsx
@@ -30,7 +30,11 @@ describe('ItemContext', () => {
                 <Accordion preExpanded={[UUIDS.FOO]}>
                     <AccordionItem uuid={UUIDS.FOO}>
                         <AccordionItemState>
-                            {(expanded: boolean): JSX.Element => (
+                            {({
+                                expanded,
+                            }: {
+                                expanded: boolean;
+                            }): JSX.Element => (
                                 <div data-testid={UUIDS.FOO}>
                                     {expanded && 'expanded'}
                                 </div>
@@ -39,7 +43,11 @@ describe('ItemContext', () => {
                     </AccordionItem>
                     <AccordionItem uuid={UUIDS.BAR}>
                         <AccordionItemState>
-                            {(expanded: boolean): JSX.Element => (
+                            {({
+                                expanded,
+                            }: {
+                                expanded: boolean;
+                            }): JSX.Element => (
                                 <div data-testid={UUIDS.BAR}>
                                     {expanded && 'expanded'}
                                 </div>

--- a/src/components/AccordionItemState.tsx
+++ b/src/components/AccordionItemState.tsx
@@ -3,14 +3,20 @@ import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
 type Props = Pick<DivAttributes, Exclude<keyof DivAttributes, 'children'>> & {
-    children(expanded?: boolean): React.ReactNode;
+    children(
+        args: Partial<{ expanded: boolean; disabled: boolean }>,
+    ): React.ReactNode;
 };
 
 export default class AccordionItemState extends React.Component<Props> {
     renderChildren = (itemContext: ItemContext): JSX.Element => {
-        const { expanded } = itemContext;
+        const { expanded, disabled } = itemContext;
 
-        return <React.Fragment>{this.props.children(expanded)}</React.Fragment>;
+        return (
+            <React.Fragment>
+                {this.props.children({ expanded, disabled })}
+            </React.Fragment>
+        );
     };
 
     render(): JSX.Element {


### PR DESCRIPTION
Adds example to demo and adds 'disabled' to AccordionItemState's render prop args.

<img width="531" alt="Screenshot 2019-03-13 at 10 28 28 AM" src="https://user-images.githubusercontent.com/12481532/54239754-fb8d9080-4580-11e9-89ee-611f819348f8.png">
