### PR TITLE
Chore/remove badges

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ src
 .npmignore
 webpack
 .nvmrc
-.travis.yml
 tsconfig.*
 tslint.json
 .editorconfig

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [react-accessible-accordion](https://springload.github.io/react-accessible-accordion/)
 [![npm](https://img.shields.io/npm/v/react-accessible-accordion.svg?style=flat-square)](https://www.npmjs.com/package/react-accessible-accordion)
-[![Build Status](https://travis-ci.org/springload/react-accessible-accordion.svg?branch=master)](https://travis-ci.org/springload/react-accessible-accordion)
 [![Dependency Status](https://david-dm.org/springload/react-accessible-accordion.svg?style=flat-square)](https://david-dm.org/springload/react-accessible-accordion)
 [![devDependency Status](https://david-dm.org/springload/react-accessible-accordion/dev-status.svg?style=flat-square)](https://david-dm.org/springload/react-accessible-accordion#info=devDependencies)
 [![Accessibility status](https://img.shields.io/badge/a11y-tested-brightgreen.svg)](http://wave.webaim.org/report#/https://springload.github.io/react-accessible-accordion/)

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -34,14 +34,6 @@
                         />
                     </a>
                     <a
-                        href="https://travis-ci.org/springload/react-accessible-accordion"
-                    >
-                        <img
-                            alt="Build Status badge"
-                            src="https://travis-ci.org/springload/react-accessible-accordion.svg?branch=master"
-                        />
-                    </a>
-                    <a
                         href="https://david-dm.org/springload/react-accessible-accordion"
                     >
                         <img

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -34,14 +34,6 @@
                         />
                     </a>
                     <a
-                        href="https://coveralls.io/github/springload/react-accessible-accordion"
-                    >
-                        <img
-                            src="https://coveralls.io/repos/github/springload/react-accessible-accordion/badge.svg"
-                            alt="Coverage Status badge"
-                        />
-                    </a>
-                    <a
                         href="https://travis-ci.org/springload/react-accessible-accordion"
                     >
                         <img


### PR DESCRIPTION
No longer advertising 100% test coverage, because we don't have 100% test coverage, because it's a misleading metric. We now have strict Typescript config, implementation-agnostic unit tests, and spec-compliance end-to-end tests, so I'm pretty confident that our testing is stronger now than it has ever been, despite a drop in coverage.

Also we had a badge in there which advertised that our build was passing on Travis... despite the fact that we no longer build on Travis 😄 