### PR TITLE
Move Vincent to 'authors' and add Github URLs for Samantha and Thibaud

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,19 +38,22 @@
         "accessible",
         "accessibility"
     ],
-    "authors": [
-        "Vincent Audebert <vincent@springload.co.nz>"
-    ],
     "contributors": [
+        {
+            "name": "Vincent Audebert",
+            "url": "https://github.com/vincentaudebert"
+        },
         {
             "name": "Mitch Ryan",
             "url": "https://github.com/ryami333"
         },
         {
-            "name": "Samantha Sanders"
+            "name": "Samantha Sanders",
+            "url": "https://github.com/samanthaksanders"
         },
         {
-            "name": "Thibaud Colas"
+            "name": "Thibaud Colas",
+            "url": "https://github.com/thibaudcolas"
         },
         {
             "name": "Cate Palmer",


### PR DESCRIPTION
Strangely, I'm not even sure that `authors` was a valid key to begin with. Docs for `package.json` suggest that it must be `author` (singular). In any case, we thought it was more appropriate to recognise Vincent on level terms with the rest of the contributors. We still love you though @vincentaudebert 😛