### PR TITLE
chore: add module entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "3.0.0",
     "description": "Accessible Accordion component for React",
     "main": "dist/umd/index.js",
+    "module": "dist/es/index.js",
     "jsnext:main": "dist/es/index.js",
     "types": "dist/types/index.d.ts",
     "scripts": {


### PR DESCRIPTION
Hello,

I've replaced  `jsnext:main` entry with `module` so it can work with rollup bundler. 
Rollup seems to not use `jsnext:main` and was using the umd build.
 it's probably safe to use module now since webpack use "module" too 
