### PR TITLE
Remove need for findIndex polyfill, change to findIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 > All notable changes to this project are documented in this file. This project
 > adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [[v3.0.1]](https://github.com/springload/react-accessible-accordion/releases/tag/v3.0.1)
+
+### CHANGED
+
+-   Modified usage for `Array.prototype.findIndex` to `Array.prototype.indexOf` across the library to remove the need for polyfill for IE 11.
+
 ## [[v3.0.0]](https://github.com/springload/react-accessible-accordion/releases/tag/v3.0.0)
 
 This release is the culmination of a massive amount of work, resulting in some

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 ## [[v3.0.1]](https://github.com/springload/react-accessible-accordion/releases/tag/v3.0.1)
 
-### CHANGED
+### FIXED
 
--   Modified usage for `Array.prototype.findIndex` to `Array.prototype.indexOf` across the library to remove the need for polyfill for IE 11.
+-   Refactor away `Array.prototype.findIndex` in favour of `Array.prototype.indexOf` to reinstate IE 11 support without use of a polyfill (https://github.com/springload/react-accessible-accordion/issues/237, https://github.com/springload/react-accessible-accordion/issues/224).
 
 ## [[v3.0.0]](https://github.com/springload/react-accessible-accordion/releases/tag/v3.0.0)
 

--- a/README.md
+++ b/README.md
@@ -246,5 +246,3 @@ controlled manually thereafter.
 | Chrome        | Desktop   | latest  |
 | Firefox       | Desktop   | latest  |
 | Safari        | OSX       | latest  |
-
->Note: This library does not have polyfill support for `Array.prototype.findIndex`, so if you require support **IE 11** you will need to add polyfill in your build or manually add it.

--- a/README.md
+++ b/README.md
@@ -246,3 +246,5 @@ controlled manually thereafter.
 | Chrome        | Desktop   | latest  |
 | Firefox       | Desktop   | latest  |
 | Safari        | OSX       | latest  |
+
+>Note: This library does not have polyfill support for `Array.prototype.findIndex`, so if you require support **IE 11** you will need to add polyfill in your build or manually add it.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
         {
             "name": "Cate Palmer",
             "url": "https://github.com/catepalmer"
+        },
+        {
+            "name": "Janzen Zarzoso",
+            "url": "https://github.com/janzenz"
         }
     ],
     "license": "MIT",

--- a/src/helpers/AccordionStore.ts
+++ b/src/helpers/AccordionStore.ts
@@ -78,11 +78,7 @@ export default class AccordionStore {
     };
 
     public readonly isItemExpanded = (uuid: UUID): boolean => {
-        return (
-            this.expanded.findIndex(
-                (expandedUuid: UUID) => expandedUuid === uuid,
-            ) !== -1
-        );
+        return this.expanded.indexOf(uuid) !== -1;
     };
 
     public readonly getPanelAttributes = (


### PR DESCRIPTION
Closes #237 #244. Adding clarification for people who are seeing error `Array.prototype.findIndex` on IE 11.