### PR TITLE
fix: header and footer cover section in demo site

### DIFF
--- a/demo/src/main.css
+++ b/demo/src/main.css
@@ -87,8 +87,10 @@ header {
 }
 
 section {
+    position: relative;
     display: flex;
     justify-content: flex-end;
+    z-index: 10;
 }
 
 footer {


### PR DESCRIPTION
The position of header and footer are fixed so they both cover section which leads you can click the accordion item in the places covered.