### PR TITLE
Assert that uuids and ids are valid HTML ids

### DIFF
--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
-import { nextUuid, assertValidHtmlId } from '../helpers/uuid';
+import { assertValidHtmlId, nextUuid } from '../helpers/uuid';
 import {
     Consumer as ItemConsumer,
     ItemContext,
@@ -43,7 +43,9 @@ export default class AccordionItem extends React.Component<Props> {
     render(): JSX.Element {
         const { uuid = this.instanceUuid, dangerouslySetExpanded } = this.props;
 
-        if (rest.id) assertValidHtmlId(rest.id);
+        if (rest.id) {
+            assertValidHtmlId(rest.id);
+        }
 
         return (
             <ItemProvider

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -41,7 +41,11 @@ export default class AccordionItem extends React.Component<Props> {
     };
 
     render(): JSX.Element {
-        const { uuid = this.instanceUuid, dangerouslySetExpanded } = this.props;
+        const {
+            uuid = this.instanceUuid,
+            dangerouslySetExpanded,
+            ...rest
+        } = this.props;
 
         if (rest.id) {
             assertValidHtmlId(rest.id);

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
-import { nextUuid } from '../helpers/uuid';
+import { nextUuid, assertValidHtmlId } from '../helpers/uuid';
 import {
     Consumer as ItemConsumer,
     ItemContext,
@@ -42,6 +42,8 @@ export default class AccordionItem extends React.Component<Props> {
 
     render(): JSX.Element {
         const { uuid = this.instanceUuid, dangerouslySetExpanded } = this.props;
+
+        if (rest.id) assertValidHtmlId(rest.id);
 
         return (
             <ItemProvider

--- a/src/components/AccordionItemButton.spec.tsx
+++ b/src/components/AccordionItemButton.spec.tsx
@@ -59,22 +59,6 @@ describe('AccordionItem', () => {
         });
     });
 
-    it('throws on invalid uuid', () => {
-        expect(() => {
-            render(
-                <Accordion>
-                    <AccordionItem uuid={UUIDS.BAD_ID}>
-                        <AccordionItemHeading>
-                            <AccordionItemButton>
-                                Hello World
-                            </AccordionItemButton>
-                        </AccordionItemHeading>
-                    </AccordionItem>
-                </Accordion>,
-            );
-        }).toThrow();
-    });
-
     describe('children prop', () => {
         it('is respected', () => {
             const { getByText } = render(

--- a/src/components/AccordionItemButton.spec.tsx
+++ b/src/components/AccordionItemButton.spec.tsx
@@ -8,6 +8,7 @@ import AccordionItemHeading from './AccordionItemHeading';
 enum UUIDS {
     FOO = 'FOO',
     BAR = 'BAR',
+    BAD_ID = 'BAD ID',
 }
 
 describe('AccordionItem', () => {
@@ -56,6 +57,22 @@ describe('AccordionItem', () => {
                 'foo',
             ]);
         });
+    });
+
+    it('throws on invalid uuid', () => {
+        expect(() => {
+            render(
+                <Accordion>
+                    <AccordionItem uuid={UUIDS.BAD_ID}>
+                        <AccordionItemHeading>
+                            <AccordionItemButton>
+                                Hello World
+                            </AccordionItemButton>
+                        </AccordionItemHeading>
+                    </AccordionItem>
+                </Accordion>,
+            );
+        }).toThrow();
     });
 
     describe('children prop', () => {

--- a/src/components/AccordionItemButton.tsx
+++ b/src/components/AccordionItemButton.tsx
@@ -11,6 +11,7 @@ import keycodes from '../helpers/keycodes';
 import { DivAttributes } from '../helpers/types';
 
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+import { assertValidHtmlId } from '../helpers/uuid';
 
 type Props = DivAttributes & {
     toggleExpanded(): void;
@@ -69,6 +70,8 @@ export class AccordionItemButton extends React.PureComponent<Props> {
 
     render(): JSX.Element {
         const { toggleExpanded, ...rest } = this.props;
+
+        if (rest.id) assertValidHtmlId(rest.id);
 
         return (
             <div

--- a/src/components/AccordionItemButton.tsx
+++ b/src/components/AccordionItemButton.tsx
@@ -9,9 +9,9 @@ import {
 } from '../helpers/focus';
 import keycodes from '../helpers/keycodes';
 import { DivAttributes } from '../helpers/types';
+import { assertValidHtmlId } from '../helpers/uuid';
 
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
-import { assertValidHtmlId } from '../helpers/uuid';
 
 type Props = DivAttributes & {
     toggleExpanded(): void;
@@ -71,7 +71,9 @@ export class AccordionItemButton extends React.PureComponent<Props> {
     render(): JSX.Element {
         const { toggleExpanded, ...rest } = this.props;
 
-        if (rest.id) assertValidHtmlId(rest.id);
+        if (rest.id) {
+            assertValidHtmlId(rest.id);
+        }
 
         return (
             <div

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -8,6 +8,7 @@ import AccordionItemHeading, { SPEC_ERROR } from './AccordionItemHeading';
 enum UUIDS {
     FOO = 'FOO',
     BAR = 'BAR',
+    BAD_ID = 'BAD ID',
 }
 
 describe('AccordionItem', () => {
@@ -56,6 +57,22 @@ describe('AccordionItem', () => {
                 'foo',
             ]);
         });
+    });
+
+    it('throws on invalid uuid', () => {
+        expect(() => {
+            render(
+                <Accordion>
+                    <AccordionItem>
+                        <AccordionItemHeading id={UUIDS.BAD_ID}>
+                            <AccordionItemButton>
+                                Hello World
+                            </AccordionItemButton>
+                        </AccordionItemHeading>
+                    </AccordionItem>
+                </Accordion>,
+            );
+        }).toThrow();
     });
 
     describe('children prop', () => {

--- a/src/components/AccordionItemHeading.spec.tsx
+++ b/src/components/AccordionItemHeading.spec.tsx
@@ -59,22 +59,6 @@ describe('AccordionItem', () => {
         });
     });
 
-    it('throws on invalid uuid', () => {
-        expect(() => {
-            render(
-                <Accordion>
-                    <AccordionItem>
-                        <AccordionItemHeading id={UUIDS.BAD_ID}>
-                            <AccordionItemButton>
-                                Hello World
-                            </AccordionItemButton>
-                        </AccordionItemHeading>
-                    </AccordionItem>
-                </Accordion>,
-            );
-        }).toThrow();
-    });
-
     describe('children prop', () => {
         it('is respected', () => {
             const { getByText } = render(

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -4,6 +4,7 @@ import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
 
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+import { assertValidHtmlId } from '../helpers/uuid';
 
 type Props = DivAttributes;
 
@@ -76,6 +77,8 @@ const AccordionItemHeadingWrapper: React.SFC<DivAttributes> = (
     <ItemConsumer>
         {(itemContext: ItemContext): JSX.Element => {
             const { headingAttributes } = itemContext;
+
+            if (props.id) assertValidHtmlId(props.id);
 
             return <AccordionItemHeading {...props} {...headingAttributes} />;
         }}

--- a/src/components/AccordionItemHeading.tsx
+++ b/src/components/AccordionItemHeading.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { InjectedHeadingAttributes } from '../helpers/AccordionStore';
 import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
+import { assertValidHtmlId } from '../helpers/uuid';
 
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
-import { assertValidHtmlId } from '../helpers/uuid';
 
 type Props = DivAttributes;
 
@@ -78,7 +78,9 @@ const AccordionItemHeadingWrapper: React.SFC<DivAttributes> = (
         {(itemContext: ItemContext): JSX.Element => {
             const { headingAttributes } = itemContext;
 
-            if (props.id) assertValidHtmlId(props.id);
+            if (props.id) {
+                assertValidHtmlId(props.id);
+            }
 
             return <AccordionItemHeading {...props} {...headingAttributes} />;
         }}

--- a/src/components/AccordionItemPanel.spec.tsx
+++ b/src/components/AccordionItemPanel.spec.tsx
@@ -54,18 +54,6 @@ describe('AccordionItem', () => {
         });
     });
 
-    it('throws on invalid id', () => {
-        expect(() => {
-            render(
-                <Accordion>
-                    <AccordionItem uuid={UUIDS.BAD_ID}>
-                        <AccordionItemPanel id={UUIDS.BAD_ID} />
-                    </AccordionItem>
-                </Accordion>,
-            );
-        }).toThrow();
-    });
-
     describe('children prop', () => {
         it('is respected', () => {
             const { getByText } = render(

--- a/src/components/AccordionItemPanel.spec.tsx
+++ b/src/components/AccordionItemPanel.spec.tsx
@@ -7,6 +7,7 @@ import AccordionItemPanel from './AccordionItemPanel';
 enum UUIDS {
     FOO = 'FOO',
     BAR = 'BAR',
+    BAD_ID = 'BAD ID',
 }
 
 describe('AccordionItem', () => {
@@ -51,6 +52,18 @@ describe('AccordionItem', () => {
                 'foo',
             ]);
         });
+    });
+
+    it('throws on invalid id', () => {
+        expect(() => {
+            render(
+                <Accordion>
+                    <AccordionItem uuid={UUIDS.BAD_ID}>
+                        <AccordionItemPanel id={UUIDS.BAD_ID} />
+                    </AccordionItem>
+                </Accordion>,
+            );
+        }).toThrow();
     });
 
     describe('children prop', () => {

--- a/src/components/AccordionItemPanel.tsx
+++ b/src/components/AccordionItemPanel.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
-import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 import { assertValidHtmlId } from '../helpers/uuid';
+import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
 type Props = DivAttributes;
 
@@ -17,7 +17,9 @@ export default class AccordionItemPanel extends React.Component<Props> {
         DisplayName.AccordionItemPanel;
 
     renderChildren = ({ panelAttributes }: ItemContext): JSX.Element => {
-        if (this.props.id) assertValidHtmlId(this.props.id);
+        if (this.props.id) {
+            assertValidHtmlId(this.props.id);
+        }
 
         return (
             <div

--- a/src/components/AccordionItemPanel.tsx
+++ b/src/components/AccordionItemPanel.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import DisplayName from '../helpers/DisplayName';
 import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+import { assertValidHtmlId } from '../helpers/uuid';
 
 type Props = DivAttributes;
 
@@ -16,6 +17,8 @@ export default class AccordionItemPanel extends React.Component<Props> {
         DisplayName.AccordionItemPanel;
 
     renderChildren = ({ panelAttributes }: ItemContext): JSX.Element => {
+        if (this.props.id) assertValidHtmlId(this.props.id);
+
         return (
             <div
                 data-accordion-component="AccordionItemPanel"

--- a/src/components/ItemContext.tsx
+++ b/src/components/ItemContext.tsx
@@ -11,7 +11,7 @@ import {
     Consumer as AccordionContextConsumer,
 } from './AccordionContext';
 
-export type UUID = string | number;
+export type UUID = string;
 
 type ProviderProps = {
     children?: React.ReactNode;

--- a/src/helpers/uuid.spec.ts
+++ b/src/helpers/uuid.spec.ts
@@ -20,7 +20,6 @@ describe('UUID helper', () => {
     describe('assertValidHtmlId', () => {
         it("returns false in case there's a whitespace or an empty string", () => {
             expect(assertValidHtmlId('a a')).toBe(false);
-            expect(assertValidHtmlId('a	a')).toBe(false);
             expect(assertValidHtmlId('')).toBe(false);
         });
 

--- a/src/helpers/uuid.spec.ts
+++ b/src/helpers/uuid.spec.ts
@@ -3,17 +3,17 @@ import { nextUuid, resetNextUuid } from './uuid';
 describe('UUID helper', () => {
     describe('nextUuid', () => {
         it('generates incremental uuids', () => {
-            expect(nextUuid()).toBe(0);
-            expect(nextUuid()).toBe(1);
+            expect(nextUuid()).toBe('raa-0');
+            expect(nextUuid()).toBe('raa-1');
         });
     });
 
     describe('resetNextUuid', () => {
         it('resets the uuid', () => {
             resetNextUuid();
-            expect(nextUuid()).toBe(0);
+            expect(nextUuid()).toBe('raa-0');
             resetNextUuid();
-            expect(nextUuid()).toBe(0);
+            expect(nextUuid()).toBe('raa-0');
         });
     });
 });

--- a/src/helpers/uuid.spec.ts
+++ b/src/helpers/uuid.spec.ts
@@ -1,4 +1,4 @@
-import { nextUuid, resetNextUuid } from './uuid';
+import { assertValidHtmlId, nextUuid, resetNextUuid } from './uuid';
 
 describe('UUID helper', () => {
     describe('nextUuid', () => {
@@ -14,6 +14,19 @@ describe('UUID helper', () => {
             expect(nextUuid()).toBe('raa-0');
             resetNextUuid();
             expect(nextUuid()).toBe('raa-0');
+        });
+    });
+
+    describe('assertValidHtmlId', () => {
+        it("returns false in case there's a whitespace or an empty string", () => {
+            expect(assertValidHtmlId('a a')).toBe(false);
+            expect(assertValidHtmlId('a	a')).toBe(false);
+            expect(assertValidHtmlId('')).toBe(false);
+        });
+
+        it('returns true on a valid id', () => {
+            expect(assertValidHtmlId('💜')).toBe(true);
+            expect(assertValidHtmlId('✅')).toBe(true);
         });
     });
 });

--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -1,14 +1,29 @@
+import { UUID } from '../components/ItemContext';
+
 const DEFAULT = 0;
 
 let counter = DEFAULT;
 
-export function nextUuid(): number {
+export function nextUuid(): UUID {
     const current = counter;
     counter = counter + 1;
 
-    return current;
+    return `raa-${current}`;
 }
 
 export function resetNextUuid(): void {
     counter = DEFAULT;
+}
+
+// https://stackoverflow.com/a/14664879
+// but modified to allow additional first characters per HTML5
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
+const idRegex = /^[_\-.a-zA-Z][\w:.-]*$/;
+
+export function assertValidHtmlId(htmlId: string): void {
+    if (!htmlId.toString().match(idRegex)) {
+        throw new Error(
+            `uuid must be a valid HTML Id but was given "${htmlId}"`,
+        );
+    }
 }

--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -15,15 +15,19 @@ export function resetNextUuid(): void {
     counter = DEFAULT;
 }
 
-// https://stackoverflow.com/a/14664879
-// but modified to allow additional first characters per HTML5
-// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
-const idRegex = /^[_\-.a-zA-Z][\w:.-]*$/;
+// HTML5 ids allow all unicode characters, except for ASCII whitespaces
+// https://infra.spec.whatwg.org/#ascii-whitespace
+const idRegex = /[\u0009\u000a\u000c\u000d\u0020]/g;
 
-export function assertValidHtmlId(htmlId: string): void {
-    if (!htmlId.toString().match(idRegex)) {
-        throw new Error(
-            `uuid must be a valid HTML Id but was given "${htmlId}"`,
+export function assertValidHtmlId(htmlId: string): boolean {
+    if (htmlId === '' || idRegex.test(htmlId)) {
+        // tslint:disable-next-line
+        console.error(
+            `uuid must be a valid HTML5 id but was given "${htmlId}", ASCII whitespaces are forbidden`,
         );
+
+        return false;
     }
+
+    return true;
 }


### PR DESCRIPTION
`InjectedPanelAttributes` includes an `id` but can generate invalid HTML ids, so this changes uuid generation to include assertions.

I found a real life example where the uuid was set using a string from a button title, so it has spaces which made it invalid.