### PR TITLE
Allow 0 to be a valid UUID

### DIFF
--- a/src/components/AccordionItem.spec.tsx
+++ b/src/components/AccordionItem.spec.tsx
@@ -1,7 +1,8 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import { default as Accordion } from './Accordion';
 import AccordionItem from './AccordionItem';
+import AccordionItemButton from './AccordionItemButton';
 
 enum UUIDS {
     FOO = 'FOO',
@@ -72,6 +73,31 @@ describe('AccordionItem', () => {
                 </Accordion>,
             );
             expect(getByText('Hello World')).toBeTruthy();
+        });
+    });
+
+    describe('uuid prop', () => {
+        it('keeps the uuid as 0 even though its falsy', () => {
+            const testId = 'el-with-zero-uuid';
+            const zero = 0;
+            let selected: (string | number)[] = [];
+            const { getByTestId } = render(
+                <Accordion
+                    onChange={(latestSelected) => {
+                        selected = latestSelected;
+                    }}
+                >
+                    <AccordionItem uuid={zero}>
+                        <AccordionItemButton data-testid={testId}>
+                            Click me
+                        </AccordionItemButton>
+                    </AccordionItem>
+                </Accordion>,
+            );
+
+            fireEvent.click(getByTestId(testId));
+
+            expect(selected).toEqual([zero]);
         });
     });
 });

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -39,7 +39,7 @@ const AccordionItem = ({
         );
     };
 
-    assertValidHtmlId(uuid);
+    assertValidHtmlId(uuid.toString());
     if (rest.id) {
         assertValidHtmlId(rest.id);
     }

--- a/src/components/AccordionItem.tsx
+++ b/src/components/AccordionItem.tsx
@@ -24,7 +24,7 @@ const AccordionItem = ({
     ...rest
 }: Props): JSX.Element => {
     const [instanceUuid] = useState<UUID>(nextUuid());
-    const uuid = customUuid || instanceUuid;
+    const uuid = customUuid ?? instanceUuid;
 
     const renderChildren = (itemContext: ItemContext): JSX.Element => {
         const { expanded } = itemContext;

--- a/src/components/ItemContext.tsx
+++ b/src/components/ItemContext.tsx
@@ -11,7 +11,7 @@ import {
     Consumer as AccordionContextConsumer,
 } from './AccordionContext';
 
-export type UUID = string;
+export type UUID = string | number;
 
 type ProviderProps = {
     children?: React.ReactNode;


### PR DESCRIPTION
Fixes #324 

Changes made: 
* Use nullish coalescing to check if a UUID is given rather than a falsy check
* Change UUID type to be a string or number
* Add a regression test